### PR TITLE
Take the default scope for the WELD bom.

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -200,16 +200,6 @@
       <version>1.2</version>
     </dependency>
 
-    <!-- WELD classes, these are present in FFDC 
-         and are sometimes instances of TCK @ShouldThrow exceptions -->
-    <dependency>
-      <groupId>org.jboss.weld</groupId>
-      <artifactId>weld-core-bom</artifactId>
-      <version>3.0.4.Final</version>
-      <scope>import</scope>
-      <type>pom</type>
-    </dependency>
-
     <!-- Sun Tools -->
 
     <dependency>
@@ -235,4 +225,23 @@
     </dependency>
 
   </dependencies>
+
+  <dependencyManagement>
+
+    <dependencies>
+
+    <!-- WELD classes, these are present in FFDC
+         and are sometimes instances of TCK @ShouldThrow exceptions -->
+    <dependency>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-core-bom</artifactId>
+      <version>3.0.4.Final</version>
+      <scope>import</scope>
+      <type>pom</type>
+    </dependency>
+
+    </dependencies>
+
+  </dependencyManagement>
+
 </project>

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -210,6 +210,16 @@
       <systemPath>${java.home}/../lib/tools.jar</systemPath>
     </dependency>
 
+    <!-- WELD classes, these are present in FFDC
+         and are sometimes instances of TCK @ShouldThrow exceptions -->
+
+    <dependency>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-core-bom</artifactId>
+      <version>3.0.4.Final</version>
+      <type>pom</type>
+    </dependency>
+
     <!-- Testing -->
 
     <dependency>
@@ -225,23 +235,5 @@
     </dependency>
 
   </dependencies>
-
-  <dependencyManagement>
-
-    <dependencies>
-
-    <!-- WELD classes, these are present in FFDC
-         and are sometimes instances of TCK @ShouldThrow exceptions -->
-    <dependency>
-      <groupId>org.jboss.weld</groupId>
-      <artifactId>weld-core-bom</artifactId>
-      <version>3.0.4.Final</version>
-      <scope>import</scope>
-      <type>pom</type>
-    </dependency>
-
-    </dependencies>
-
-  </dependencyManagement>
 
 </project>


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>

#### Short description of what this resolves:

See #11 

#### Changes proposed in this pull request:

move the weld bom to the dependencyManagement section of the pom
for liberty managed


**Fixes**: #11
