### PR TITLE
Toleration for Java 9 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 jdk:
     - openjdk7
     - oraclejdk8
+    - openjdk9
 env:
     - RUNTIME=ol RUNTIME_VERSION=18.0.0.1
     - RUNTIME=ol RUNTIME_VERSION=17.0.0.4

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -28,7 +28,6 @@
       <activation>
         <jdk>[1.9,)</jdk>
       </activation>
-      <dependencies/>
     </profile>
     <profile>
       <id>non-jigsaw</id>

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -12,7 +12,7 @@
 
   <!-- Model Version -->
   <modelVersion>4.0.0</modelVersion>
-
+  
   <!-- Artifact Configuration -->
   <artifactId>arquillian-liberty-managed</artifactId>
   <name>Arquillian Container Liberty Managed</name>
@@ -21,6 +21,31 @@
   <properties>
     <skipTests>false</skipTests>
   </properties>
+
+  <profiles>
+    <profile>
+      <id>jigsaw</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <dependencies/>
+    </profile>
+    <profile>
+      <id>non-jigsaw</id>
+      <activation>
+        <jdk>[1.0,1.9)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.6.0</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <!-- Build -->
   <build>
@@ -198,16 +223,6 @@
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <version>1.2</version>
-    </dependency>
-
-    <!-- Sun Tools -->
-
-    <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.6.0</version>
-      <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
     </dependency>
 
     <!-- WELD classes, these are present in FFDC

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -25,7 +25,6 @@
       <activation>
         <jdk>[1.9,)</jdk>
       </activation>
-      <dependencies/>
     </profile>
     <profile>
       <id>non-jigsaw</id>

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -18,6 +18,31 @@
     <version.jackson>2.4.4</version.jackson>
     <version.apache.fluent.hc>4.3.6</version.apache.fluent.hc>
   </properties>
+  
+  <profiles>
+    <profile>
+      <id>jigsaw</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <dependencies/>
+    </profile>
+    <profile>
+      <id>non-jigsaw</id>
+      <activation>
+        <jdk>[1.0,1.9)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.6.0</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
@@ -150,16 +175,6 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
-    </dependency>
-
-    <!-- Sun Tools -->
-
-    <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.6.0</version>
-      <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
     </dependency>
 
     <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <version.surefire.plugin>2.21.0</version.surefire.plugin>
 
     <!-- override from parent -->
-    <maven.compiler.target>1.5</maven.compiler.target>
-    <maven.compiler.source>1.5</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
As of Java 9 the $JAVA_HOME/lib/tools.jar was removed and converted
to a module. Made the dependency on the jar option for JDK 9+. Also,
upgrading the default compiler compliance to JDK 1.7 since javac no
longer supports -source 1.5 as of JDK 9.  Liberty itself requires a
minimum of JDK 1.7 as well.

Signed-off-by: Andrew Guibert <andy.guibert@gmail.com>

**Fixes**: #13 
