### PR TITLE
Update WLPManagedContainer.java

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1146,7 +1146,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
           * and throw it to Arquillian.
           */
          while ((line = br.readLine()) != null) {
-            if (line.contains("CWWKZ0002") && line.contains(applicationName)) {
+            if (line.contains("CWWKZ0002") && line.contains(" " + applicationName + " ")) {
                StringBuilder sb = new StringBuilder();
                sb.append("Failed to deploy ")
                      .append(applicationName)
@@ -1183,7 +1183,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
                   log.finest("A exception was found in line " + line + " of file " + messagesFilePath);
                   throw new DeploymentException(sb.toString(), ffdcXChain);
                }
-            } else if (line.contains("CWWKZ0001I") && line.contains(applicationName)) {
+            } else if (line.contains("CWWKZ0001I") && line.contains(" " + applicationName + " ")) {
                throw new DeploymentException("Application " + applicationName +
                      " started unexpectedly even though it never reached the STARTED state. This should never happen.");
             }


### PR DESCRIPTION
Pad the application name with spaces so that when it searches for an application name, it doesn't find one that is really a different app name.  For example, I got the "this should never happen" message because it searched for `CWWKZ0001I.*ExceptionMapperTest` - and found this line: `CWWKZ0001I: Application DefaultExceptionMapperTest started in 2.086 seconds.`

This change should prevent this type of mismatch.

#### Short description of what this resolves:

Avoid false positives when looking for app started messages in the logs.

#### Changes proposed in this pull request:

- WLPManagedContainer.java - padding the app name with a leading and training space to ensure it doesn't falsely match a similar appName already started in the logs.



**Fixes**: #
let me know if you need an issue for this.  It seems pretty trivial, so I'd prefer not to create an issue.
