### PR TITLE
Find last deployment error

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1146,7 +1146,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
           * and throw it to Arquillian.
           */
          while ((line = br.readLine()) != null) {
-            if (line.contains("CWWKZ0002") && line.contains(" " + applicationName + " ")) {
+            if (line.contains("CWWKZ0002") && line.contains(applicationName)) {
                StringBuilder sb = new StringBuilder();
                sb.append("Failed to deploy ")
                      .append(applicationName)
@@ -1183,7 +1183,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
                   log.finest("A exception was found in line " + line + " of file " + messagesFilePath);
                   throw new DeploymentException(sb.toString(), ffdcXChain);
                }
-            } else if (line.contains("CWWKZ0001I") && line.contains(" " + applicationName + " ")) {
+            } else if (line.contains("CWWKZ0001I") && line.contains(applicationName)) {
                throw new DeploymentException("Application " + applicationName +
                      " started unexpectedly even though it never reached the STARTED state. This should never happen.");
             }

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/InvalidBean.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/InvalidBean.java
@@ -1,0 +1,17 @@
+package io.openliberty.arquillian.managed;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * This bean should result in a definition error because it has a public non-static field and is not Dependent scoped
+ */
+@ApplicationScoped
+public class InvalidBean {
+    
+    public String foo = "test";
+    
+    public String getFoo() {
+        return foo;
+    }
+
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNamePart1.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNamePart1.java
@@ -1,0 +1,29 @@
+package io.openliberty.arquillian.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Run from the {@link WLPDuplicateAppNameTest} suite because ordering is important.
+ * <p>
+ * Note: This test doesn't get run by surefire directly because its name doesn't start or end in "Test"
+ */
+@RunWith(Arquillian.class)
+public class WLPDuplicateAppNamePart1 {
+
+    @Deployment
+    public static WebArchive createDeployment() 
+    {
+       return ShrinkWrap.create(WebArchive.class, "duplicateName.war")
+               .addClass(HelloServlet.class);
+    }
+    
+    @Test
+    public void duplicateName1Deploys() {
+        // Just want to check it deploys correctly
+    }
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNamePart2.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNamePart2.java
@@ -1,0 +1,33 @@
+package io.openliberty.arquillian.managed;
+
+import javax.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Run from the {@link WLPDuplicateAppNameTest} suite because ordering is important.
+ * <p>
+ * Note: This test doesn't get run by surefire directly because its name doesn't start or end in "Test"
+ */
+@RunWith(Arquillian.class)
+public class WLPDuplicateAppNamePart2 {
+
+    @ShouldThrowException(DefinitionException.class)
+    @Deployment
+    public static WebArchive createInvalidDeployment()
+    {
+        return ShrinkWrap.create(WebArchive.class, "duplicateName.war")
+                .addClass(InvalidBean.class);
+    }
+    
+    @Test
+    public void deploymentExceptionThrown() {
+        // No assertion needed here. Just want to check that the @ShouldThrowException above is honoured
+    }
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNameTest.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNameTest.java
@@ -1,0 +1,21 @@
+package io.openliberty.arquillian.managed;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+              WLPDuplicateAppNamePart1.class,
+              WLPDuplicateAppNamePart2.class
+})
+/**
+ * Test that we can deploy an app successfully, and then deploy an invalid app
+ * with the same name and process the deployment exception correctly
+ * <p>
+ * Arquillian checks for two deployments in the same test having the same
+ * archive name, so this situation is only possible if the two apps are deployed
+ * in different tests. Therefore we have to use a suite to ensure we execute
+ * them in the correct order.
+ */
+public class WLPDuplicateAppNameTest {}


### PR DESCRIPTION
#### Short description of what this resolves:

The following message is seen if an app is deployed successfully, is removed and then an app with the same name fails to deploy within the lifetime of a server.

`org.jboss.arquillian.container.spi.client.container.DeploymentException: Application appName started unexpectedly even though it never reached the STARTED state. This should never happen.`

#### Changes proposed in this pull request:

- when scanning the log for the line reporting the app starting or failing to start, look for the last matching line in the file as this will be the app which was just deployed.
- add a test for this scenario (test uses a suite to ensure the correct ordering of deployments)
- revert #23 
  - in some messages, the application name is not surrounded by spaces
  - with this PR, the problem which #23 was attempting to address should no longer occur

**Fixes**: #15 