### PR TITLE
Make use of ibm-web-ext.xml to retrieve context-root for liberty-managed

### DIFF
--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/OtherFooServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/OtherFooServlet.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018, IBM Corporation, and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.needsmanagementmbeans;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/otherFoo")
+public class OtherFooServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("I am other foo");
+    }
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPContextRootTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPContextRootTestCase.java
@@ -116,7 +116,7 @@ public class WLPContextRootTestCase
    }
    
    @Test
-   public void testIfBarContextRootMatchesWebExtValue() throws Exception {
+   public void testIfBarContextRootMatchesApplicationXmlValue() throws Exception {
        URL url = new URL(barContextRoot, "bar");
        assertEquals("/test1/", barContextRoot.getPath());
        String response = readAllAndClose(url.openStream());
@@ -124,7 +124,7 @@ public class WLPContextRootTestCase
    }
    
    @Test
-   public void testIfBazContextRootMatchesApplicationXml() throws Exception {
+   public void testIfBazContextRootMatchesWebExtValue() throws Exception {
        URL url = new URL(bazContextRoot, "baz");
        assertEquals("/contextRootFromWebExt3/", bazContextRoot.getPath());
        String response = readAllAndClose(url.openStream());

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPContextRootTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPContextRootTestCase.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2010-2012, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.needsmanagementmbeans;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.application7.ApplicationDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class WLPContextRootTestCase
+{
+	
+    private static final String DEPLOYMENT1 = "app1";
+    private static final String DEPLOYMENT2 = "app2";
+    private static final String DEPLOYMENT3 = "app3";
+    private static final String DEPLOYMENT4 = "app4";
+
+    @Deployment(testable = false, name = DEPLOYMENT1)
+    public static WebArchive app1() {
+        return ShrinkWrap.create(WebArchive.class, "testApp1.war")
+                .addClass(FooServlet.class);
+    }
+    
+    @Deployment(testable = false, name = DEPLOYMENT2)
+    public static WebArchive app2() {
+        return ShrinkWrap.create(WebArchive.class, "testApp2.war")
+        		.addAsWebInfResource(new File("src/test/resources/ibm-web-ext_1.xml"), "ibm-web-ext.xml")
+                .addClass(OtherFooServlet.class);
+    }
+    
+    @Deployment(testable = false, name = DEPLOYMENT3)
+    public static EnterpriseArchive app3() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "testApp3.ear")
+            .addAsModule(ShrinkWrap.create(WebArchive.class, "test1.war")
+                 .addClass(BarServlet.class)
+           		 .addAsWebInfResource(new File("src/test/resources/ibm-web-ext_2.xml"), "ibm-web-ext.xml"));                			 
+                			 
+        ApplicationDescriptor appXml = Descriptors.create(ApplicationDescriptor.class)
+                                                     .version(ApplicationDescriptor.VERSION)
+                                                     .applicationName("testApp3")
+                                                     .createModule().getOrCreateWeb().contextRoot("/test1").webUri("test1.war").up().up();
+        ear.setApplicationXML(new StringAsset(appXml.exportAsString()));
+        
+        return ear;
+   }
+    
+    @Deployment(testable = false, name = DEPLOYMENT4)
+    public static EnterpriseArchive app4() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "testApp4.ear")
+            .addAsModule(ShrinkWrap.create(WebArchive.class, "test2.war")
+                 .addClass(BazServlet.class)
+				 .addAsWebInfResource(new File("src/test/resources/ibm-web-ext_3.xml"), "ibm-web-ext.xml"));
+        
+        return ear;
+   }
+    
+    
+   @ArquillianResource(FooServlet.class)
+   @OperateOnDeployment(DEPLOYMENT1)
+   private URL fooContextRoot;
+    
+   @ArquillianResource(OtherFooServlet.class)
+   @OperateOnDeployment(DEPLOYMENT2)
+   private URL otherFooContextRoot;
+    
+   @ArquillianResource(BarServlet.class)
+   @OperateOnDeployment(DEPLOYMENT3)
+   private URL barContextRoot;
+   
+   @ArquillianResource(BazServlet.class)
+   @OperateOnDeployment(DEPLOYMENT4)
+   private URL bazContextRoot;    
+
+   @Test
+   public void testIfFooContextRootMatchesWarName() throws Exception {
+       URL url = new URL(fooContextRoot, "foo");
+       assertEquals("/testApp1/", fooContextRoot.getPath());
+       String response = readAllAndClose(url.openStream());
+       assertEquals("I am foo", response);
+   }
+
+   @Test
+   public void testIfOtherFooContextRootMatchesWebExtValue() throws Exception {
+       URL url = new URL(otherFooContextRoot, "otherFoo");
+       assertEquals("/contextRootFromWebExt1/", otherFooContextRoot.getPath());
+       String response = readAllAndClose(url.openStream());
+       assertEquals("I am other foo", response);
+   }
+   
+   @Test
+   public void testIfBarContextRootMatchesWebExtValue() throws Exception {
+       URL url = new URL(barContextRoot, "bar");
+       assertEquals("/test1/", barContextRoot.getPath());
+       String response = readAllAndClose(url.openStream());
+       assertEquals("I am bar", response);
+   }
+   
+   @Test
+   public void testIfBazContextRootMatchesApplicationXml() throws Exception {
+       URL url = new URL(bazContextRoot, "baz");
+       assertEquals("/contextRootFromWebExt3/", bazContextRoot.getPath());
+       String response = readAllAndClose(url.openStream());
+       assertEquals("I am baz", response);
+   }
+   
+   private String readAllAndClose(InputStream is) throws Exception 
+   {
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try
+      {
+         int read;
+         while( (read = is.read()) != -1)
+         {
+            out.write(read);
+         }
+      }
+      finally 
+      {
+         try { is.close(); } catch (Exception e) { }
+      }
+      return out.toString();
+   }
+   
+   
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPContextRootTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPContextRootTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2012, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2018, IBM Corporation, and other contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,78 +37,81 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class WLPContextRootTestCase
 {
-	
     private static final String DEPLOYMENT1 = "app1";
     private static final String DEPLOYMENT2 = "app2";
     private static final String DEPLOYMENT3 = "app3";
     private static final String DEPLOYMENT4 = "app4";
-
+    
     @Deployment(testable = false, name = DEPLOYMENT1)
-    public static WebArchive app1() {
+    public static WebArchive app1()
+    {
         return ShrinkWrap.create(WebArchive.class, "testApp1.war")
                 .addClass(FooServlet.class);
     }
     
     @Deployment(testable = false, name = DEPLOYMENT2)
-    public static WebArchive app2() {
+    public static WebArchive app2()
+    {
         return ShrinkWrap.create(WebArchive.class, "testApp2.war")
-        		.addAsWebInfResource(new File("src/test/resources/ibm-web-ext_1.xml"), "ibm-web-ext.xml")
-                .addClass(OtherFooServlet.class);
+            .addAsWebInfResource(new File("src/test/resources/ibm-web-ext_1.xml"), "ibm-web-ext.xml")
+            .addClass(OtherFooServlet.class);
     }
     
     @Deployment(testable = false, name = DEPLOYMENT3)
-    public static EnterpriseArchive app3() {
+    public static EnterpriseArchive app3() 
+    {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "testApp3.ear")
             .addAsModule(ShrinkWrap.create(WebArchive.class, "test1.war")
-                 .addClass(BarServlet.class)
-           		 .addAsWebInfResource(new File("src/test/resources/ibm-web-ext_2.xml"), "ibm-web-ext.xml"));                			 
-                			 
+                .addClass(BarServlet.class)
+                .addAsWebInfResource(new File("src/test/resources/ibm-web-ext_2.xml"), "ibm-web-ext.xml"));
+        
         ApplicationDescriptor appXml = Descriptors.create(ApplicationDescriptor.class)
-                                                     .version(ApplicationDescriptor.VERSION)
-                                                     .applicationName("testApp3")
-                                                     .createModule().getOrCreateWeb().contextRoot("/test1").webUri("test1.war").up().up();
+           .version(ApplicationDescriptor.VERSION)
+           .applicationName("testApp3")
+           .createModule().getOrCreateWeb().contextRoot("/test1").webUri("test1.war").up().up();
         ear.setApplicationXML(new StringAsset(appXml.exportAsString()));
         
         return ear;
    }
     
     @Deployment(testable = false, name = DEPLOYMENT4)
-    public static EnterpriseArchive app4() {
+    public static EnterpriseArchive app4() 
+    {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "testApp4.ear")
             .addAsModule(ShrinkWrap.create(WebArchive.class, "test2.war")
-                 .addClass(BazServlet.class)
-				 .addAsWebInfResource(new File("src/test/resources/ibm-web-ext_3.xml"), "ibm-web-ext.xml"));
-        
+                .addClass(BazServlet.class)
+                .addAsWebInfResource(new File("src/test/resources/ibm-web-ext_3.xml"), "ibm-web-ext.xml"));
         return ear;
    }
-    
     
    @ArquillianResource(FooServlet.class)
    @OperateOnDeployment(DEPLOYMENT1)
    private URL fooContextRoot;
-    
+   
    @ArquillianResource(OtherFooServlet.class)
    @OperateOnDeployment(DEPLOYMENT2)
    private URL otherFooContextRoot;
-    
+   
    @ArquillianResource(BarServlet.class)
    @OperateOnDeployment(DEPLOYMENT3)
    private URL barContextRoot;
    
    @ArquillianResource(BazServlet.class)
    @OperateOnDeployment(DEPLOYMENT4)
-   private URL bazContextRoot;    
-
+   private URL bazContextRoot;
+   
    @Test
-   public void testIfFooContextRootMatchesWarName() throws Exception {
+   public void testIfFooContextRootMatchesWarName() throws Exception 
+   {
        URL url = new URL(fooContextRoot, "foo");
        assertEquals("/testApp1/", fooContextRoot.getPath());
        String response = readAllAndClose(url.openStream());
        assertEquals("I am foo", response);
    }
-
+   
    @Test
-   public void testIfOtherFooContextRootMatchesWebExtValue() throws Exception {
+   public void testIfOtherFooContextRootMatchesWebExtValue() throws Exception 
+   {
        URL url = new URL(otherFooContextRoot, "otherFoo");
        assertEquals("/contextRootFromWebExt1/", otherFooContextRoot.getPath());
        String response = readAllAndClose(url.openStream());
@@ -116,7 +119,8 @@ public class WLPContextRootTestCase
    }
    
    @Test
-   public void testIfBarContextRootMatchesApplicationXmlValue() throws Exception {
+   public void testIfBarContextRootMatchesApplicationXmlValue() throws Exception 
+   {
        URL url = new URL(barContextRoot, "bar");
        assertEquals("/test1/", barContextRoot.getPath());
        String response = readAllAndClose(url.openStream());
@@ -148,6 +152,4 @@ public class WLPContextRootTestCase
       }
       return out.toString();
    }
-   
-   
 }

--- a/liberty-managed/src/test/resources/ibm-web-ext_1.xml
+++ b/liberty-managed/src/test/resources/ibm-web-ext_1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-ext xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd" version="1.0">
+  <context-root uri="/contextRootFromWebExt1"/>
+</web-ext>
+

--- a/liberty-managed/src/test/resources/ibm-web-ext_2.xml
+++ b/liberty-managed/src/test/resources/ibm-web-ext_2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-ext xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd" version="1.0">
+  <context-root uri="/contextRootFromWebExt2"/>
+</web-ext>
+

--- a/liberty-managed/src/test/resources/ibm-web-ext_3.xml
+++ b/liberty-managed/src/test/resources/ibm-web-ext_3.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-ext xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd" version="1.0">
+  <context-root uri="/contextRootFromWebExt3"/>
+</web-ext>
+


### PR DESCRIPTION
#### Short description of what this resolves:

For EAR deployments, the application.xml is optional since JavaEE 5. Websphere Liberty (and even Traditional) support to define a web archive's context root using the IBM specific web application descriptor file ibm-web-ext.xml:

```
<?xml version="1.0" encoding="UTF-8"?>
<web-ext xmlns:xsi="..." ...>
  <context-root uri="/webshop"/>
</web-ext>
```

Unfortunately, WLPManagedContainer only looks up the context root in the ear's application xml.
When there is no application.xml found, it falls back to use the archive name as context root.
In our application the context root doesn't match the archive name and changing both is not possible due to compatibility reasons.

#### Changes proposed in this pull request
- Access ibm-web-ext.xml to determine context-root for web archives in managed mode.

**Fixes**: #26 

#### Additional Information

Please let me know if there is more required for this pull request.

Thanks!
Christian
