### PR TITLE
Allow to set WLP_USER_DIR via enrivonment

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1102,8 +1102,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
                // We can safely ignore FileNotFound
             }
             // Process environment variables
-            if (value == null && !key.equals(WLP_USER_DIR)) { // WLP_USER_DIR can be specified only in the
-                                                              // ${wlp.install.dir}/etc/server.env file
+            if (value == null) {
                value = getEnv(key);
             }
          }


### PR DESCRIPTION
#### Short description of what this resolves:
WLP_USER_DIR can currently not be externally specified for the liberty-managed container extension (see #28).

#### Changes proposed in this pull request:
- Allow "WLP_USER_DIR" to be defined as test process environment variable

**Fixes**: #28 