### PR TITLE
Fixed J2EEManagement request to determine servlet names

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -516,7 +516,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
            if (path.get().endsWith("war")) {
                WebModule module = new WebModule();
                module.archive = ear.getAsType(WebArchive.class, path);
-               module.name = module.archive.getName().replaceFirst("\\.war$", "");
+               module.name = module.archive.getName().replaceFirst("^\\/", "").replaceFirst("\\.war$", "");
                module.contextRoot = getContextRoot(ear, module.archive);
                modules.add(module);
            }
@@ -532,7 +532,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
    private List<String> getServletNames(String appDeployName, WebModule webModule) throws DeploymentException {
        try {
            // If Java EE Management MBeans are present, query them for deployed servlets. This requires j2eeManagement-1.1 feature
-           Set<ObjectInstance> servletMbeans = mbsc.queryMBeans(new ObjectName("WebSphere:*,J2EEApplication=" + appDeployName + ",j2eeType=Servlet,WebModule="+webModule.name), null);
+           Set<ObjectInstance> servletMbeans = mbsc.queryMBeans(new ObjectName("WebSphere:*,J2EEServer=" + containerConfiguration.getServerName() + ",J2EEApplication=" + appDeployName + ",j2eeType=Servlet,WebModule="+webModule.name), null);
            List<String> servletNames = new ArrayList<String>();
            
            for (ObjectInstance servletMbean : servletMbeans) {

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -532,7 +532,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
    private List<String> getServletNames(String appDeployName, WebModule webModule) throws DeploymentException {
        try {
            // If Java EE Management MBeans are present, query them for deployed servlets. This requires j2eeManagement-1.1 feature
-           Set<ObjectInstance> servletMbeans = mbsc.queryMBeans(new ObjectName("WebSphere:*,J2EEServer=" + containerConfiguration.getServerName() + ",J2EEApplication=" + appDeployName + ",j2eeType=Servlet,WebModule="+webModule.name), null);
+           Set<ObjectInstance> servletMbeans = mbsc.queryMBeans(new ObjectName("WebSphere:*,J2EEApplication=" + appDeployName + ",j2eeType=Servlet,WebModule="+webModule.name), null);
            List<String> servletNames = new ArrayList<String>();
            
            for (ObjectInstance servletMbean : servletMbeans) {

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BuzServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BuzServlet.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018, IBM Corporation, and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.needsmanagementmbeans;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/buz")
+public class BuzServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("I am buz");
+    }
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPInjectServletContextTest.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/WLPInjectServletContextTest.java
@@ -71,24 +71,25 @@ public class WLPInjectServletContextTest
     
     @Deployment(testable = false, name = DEPLOYMENT3)
     public static EnterpriseArchive app3() {
-    	
+
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class)
                 .addAsModule(ShrinkWrap.create(WebArchive.class, "test3.war")
-                             .addClass(BuzServlet.class));
-    	
-    	File deploymentFile = new File ("target/testAppWithLoadedFromFile.ear");
-    	
+                        .addClass(BuzServlet.class));
+
+        File deploymentFile = new File("target/testAppWithLoadedFromFile.ear");
+
         ApplicationDescriptor appXml = Descriptors.create(ApplicationDescriptor.class)
                 .version(ApplicationDescriptor.VERSION)
                 .applicationName("testAppWithLoadedFromFile")
                 .createModule().getOrCreateWeb().contextRoot("/test3").webUri("test3.war").up().up();
         ear.setApplicationXML(new StringAsset(appXml.exportAsString()));
-    	ear.as(ZipExporter.class).exportTo(deploymentFile, true);
-    	
-    	// Create the ShrinkWrap archive from file system, which leads to leading slashes '/' in the
-    	// web module names.
-    	
-		return ShrinkWrap.createFromZipFile(EnterpriseArchive.class, deploymentFile);
+        ear.as(ZipExporter.class).exportTo(deploymentFile, true);
+
+        // Create the ShrinkWrap archive from file system, which leads to leading
+        // slashes '/' in the
+        // web module names.
+
+        return ShrinkWrap.createFromZipFile(EnterpriseArchive.class, deploymentFile);
     }
     
     @ArquillianResource(FooServlet.class)


### PR DESCRIPTION
#### Short description of what this resolves:
Corrected JMX call to retrieve Servlet names within WLPManagedContainer implementation

#### Changes proposed in this pull request:

- Remove leading slash "/" for webArchive name to fix JMX request
- Add J2EEServer=<containerConfiguration.serverName> to JMX request
- Without specifying the serverName, the JMX request produces an empty result list for WLP 18.0.0.2 with JavaEE7 and J2EEManagement features enabled

**Fixes**: #30 

Feel free to contact me if I can do anything to improve this PR. 

Thank you very much!

Regards
Christian Bürenheide
