### PR TITLE
More reliable exception reporting

### DIFF
--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -17,6 +17,8 @@ The following features are required in the `server.xml` of the Liberty server.
 <featureManager>
     <feature>jsp-2.2</feature>
     <feature>localConnector-1.0</feature>
+    <feature>j2eeManagement-1.1</feature> <!-- Optional, needed to allow injection on ArquillianResources related to servlets -->
+    <feature>usr:arquillian-support-1.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
 </featureManager>
 ```
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -204,6 +204,13 @@
       <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <version>4.5.6</version>
+    </dependency>
+    
 
     <!-- Java EE Spec APIs -->
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -103,6 +103,7 @@
             </property>
           </systemProperties>
           <argLine>-Dproject.build.directory=${project.build.directory}</argLine>
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
         <executions>
           <execution>

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -92,6 +92,33 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>extract-support-feature</id>
+            <phase>test</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <artifactItems>
+            <artifactItem>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>arquillian-liberty-support</artifactId>
+              <version>${project.version}</version>
+              <type>zip</type>
+              <classifier>feature</classifier>
+              <overWrite>false</overWrite>
+              <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
+            </artifactItem>
+          </artifactItems>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${version.surefire.plugin}</version>
         <configuration>
@@ -121,6 +148,7 @@
               </systemPropertyVariables>
               <excludes>
                 <exclude>**/needsmanagementmbeans/**</exclude>
+                <exclude>**/needssupportfeature/**</exclude>
               </excludes>
             </configuration>
           </execution>
@@ -138,6 +166,7 @@
               </systemPropertyVariables>
               <excludes>
                 <exclude>**/needsmanagementmbeans/**</exclude>
+                <exclude>**/needssupportfeature/**</exclude>
               </excludes>
             </configuration>
           </execution>
@@ -253,6 +282,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>arquillian-liberty-support</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -21,20 +21,15 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,10 +40,7 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import javax.enterprise.inject.spi.DefinitionException;
 import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectInstance;
@@ -93,6 +85,9 @@ import org.xml.sax.SAXException;
 
 import com.sun.tools.attach.VirtualMachine;
 import com.sun.tools.attach.VirtualMachineDescriptor;
+
+import io.openliberty.arquillian.managed.exceptions.CDILogExceptionLocator;
+import io.openliberty.arquillian.managed.exceptions.FFDCExceptionLocator;
 
 public class WLPManagedContainer implements DeployableContainer<WLPManagedContainerConfiguration>
 {
@@ -1249,42 +1244,32 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
              /* The error message may not have showed up in the log yet. Check again on next pass. */
              log.finest("The application deployment failure message was not found. Waiting...");
          } else if (bestLine.contains("CWWKZ0002")) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("Failed to deploy ")
-                  .append(applicationName)
-                  .append(" on ")
-                  .append(containerConfiguration.getServerName());
+           log.finest("A exception was found in line " + bestLine + " of file " + messagesFilePath);
 
-            Throwable ffdcXChain = getFfdcWithNestedCauseChain(applicationName);
-
-            if (bestLine.contains("DefinitionException")) {
-               log.finest("DefinitionException found in line" + bestLine + " of file " + messagesFilePath);
-               DefinitionException cause = new javax.enterprise.inject.spi.DefinitionException(bestLine, ffdcXChain);
-               throw new DeploymentException(sb.toString(), cause);
-            } else if (bestLine.contains("DeploymentException") ||
-                       bestLine.contains("InconsistentSpecializationException") ||
-                       bestLine.contains("UnserializableDependencyException")) {
-               /*
-                * The CDI specification allows an implementation to throw a subclass of
-                * javax.enterprise.inject.spi.DeploymentException. Weld has three types
-                * such exceptions:
-                *  - org.jboss.weld.exceptions.DeploymentException
-                *  - org.jboss.weld.exceptions.InconsistentSpecializationException
-                *  - org.jboss.weld.exceptions.UnserializableDependencyException
-                */
-               log.finest("DeploymentException found in line" + bestLine + " of file " + messagesFilePath);
-               javax.enterprise.inject.spi.DeploymentException cause = new javax.enterprise.inject.spi.DeploymentException(bestLine, ffdcXChain);
-               throw new DeploymentException(sb.toString(), cause);
-            } else {
-               /*
-                * Application failed to deploy due to some other exception.
-                */
-               String exceptionFound = bestLine.substring(bestLine.indexOf("The exception message was: ") + 27);
-               sb.append(": ");
-               sb.append(exceptionFound);
-               log.finest("A exception was found in line " + bestLine + " of file " + messagesFilePath);
-               throw new DeploymentException(sb.toString(), ffdcXChain);
-            }
+           // Attempt to find the exception that occurred on the server
+           FFDCExceptionLocator ffdcLocator = new FFDCExceptionLocator(getLogsDirectory());
+           CDILogExceptionLocator cdiLocator = new CDILogExceptionLocator();
+           
+           long deploymentTime = archiveDeployTimes.get(applicationName);
+           
+           Throwable serverException = ffdcLocator.getException(applicationName, bestLine, deploymentTime);
+           
+           if (serverException == null) {
+               serverException = cdiLocator.getException(applicationName, bestLine, deploymentTime);
+           }
+           
+           // Now build the DeploymentException message
+           String loggedException = bestLine.substring(bestLine.indexOf("The exception message was: ") + 27);
+           StringBuilder deploymemtExceptionMessage = new StringBuilder();
+           deploymemtExceptionMessage.append("Failed to deploy ")
+                 .append(applicationName)
+                 .append(" on ")
+                 .append(containerConfiguration.getServerName())
+                 .append(": ")
+                 .append(loggedException);
+           
+           throw new DeploymentException(deploymemtExceptionMessage.toString(), serverException);
+           
          } else if (bestLine.contains("CWWKZ0001I") && bestLine.contains(applicationName)) {
             throw new DeploymentException("Application " + applicationName +
                   " started unexpectedly even though it never reached the STARTED state. This should never happen.");
@@ -1303,360 +1288,6 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
       }
    }
    
-   /**
-    * This method is called when we see a CWWKZ0002 in the messages log. Its job is
-    * to return an Exception with the causal chain of exceptions that is expressed
-    * in the FFDC log file for the application. It it written to use only Java 6
-    * methods.
-    * 
-    * @param applicationName
-    * @return the exception chain
-    */
-   private Throwable getFfdcWithNestedCauseChain(String appName) {
-
-       // Get the set of ffdc files
-       File[] ffdcFiles = getFfdcFilesSince(archiveDeployTimes.get(appName));
-
-       // Get StateChangeException FFDC file for this application
-       File ffdc = findStateChangeExceptionFfdcFileForApp(appName, ffdcFiles);
-
-       Throwable cause = null;
-
-       if (ffdc != null) {
-           // Get StateChangeException ffdc exception names and info chain
-           ArrayList<ExMsg> chain = getExceptionCausalChain(ffdc);
-
-           if (chain != null) {
-               cause = buildNestedException(chain);
-           }
-       }
-
-       for (Throwable c = cause; c != null; c = c.getCause()) {
-           log.finest("FFDC Exception Chain:" + c.getClass());
-       }
-
-       return cause;
-
-   }
-
-   /**
-    * Create and return the nested FFDC exception chain as a Throwable with
-    * cause(s)
-    * 
-    * @param exs
-    *            - an ordered list of the Exception log messages
-    * @return a Throwable with usable causal chain
-    */
-   private Throwable buildNestedException(ArrayList<ExMsg> exs) {
-
-       Throwable causeSoFar = null;
-
-       for (int nestLevel = exs.size() - 1; nestLevel >= 0; nestLevel--) {
-           causeSoFar = createException(exs.get(nestLevel), causeSoFar);
-       }
-
-       return causeSoFar;
-   }
-
-   /**
-    * Turn a FFDC log line into a Throwable object. This depends on Class.forname
-    * loading so maven pom dependencies need to include classes that need to be
-    * loaded on the classpath
-    * 
-    * @param x - the exception message object
-    * @param cause - something to nest inside the Throwable we create - can be null
-    * @return - a non-null Throwable that reflects the log Line as well as
-    *           possible. Note that fully 'private' classes are unlikely to be in
-    *           tests' @ShouldThrow tests anyway - so in that case the important 
-    *           thing is to not break the causal chain with this link. 
-    *           We may have private subclasses of public Exceptions - we don't handle, 
-    *           but these should be treated as special cases, handled elsewhere - for
-    *           example with a service loaded DeploymentExceptionTransformer.
-    */
-   private Throwable createException(ExMsg x, Throwable cause) {
-
-       Class<?> clazz = null;
-
-       // Can we load the server's exception class here in the container?
-       try {
-           clazz = Class.forName(x.exName);
-           log.info("Class loaded ok for name " + x.exName + " " + clazz.getName());
-
-       } catch (ClassNotFoundException e1) {
-           log.warning(
-                   "Unable to load a class for: " + x.exName + " switching to " 
-                   + UnloadableLogError.class.getName());
-           clazz = UnloadableLogError.class;
-       }
-
-       // Is the class a valid link in an exception chain
-       if (clazz != null && !Throwable.class.isAssignableFrom(clazz)) {
-           log.warning("Loadable class: " + clazz.getName() + " from  " + x 
-                   + " is not assignable to Throwable.");
-           clazz = UnloadableLogError.class;
-       }
-
-       Throwable thisServerThrowable = null;
-
-       log.finest("Attempting to load Throwable: " + clazz.getName());
-       try {
-
-           Constructor<?> xCon = null;
-           if (cause == null) {
-               try {
-                   // Ideally we want to add the FFDC log line
-                   xCon = clazz.getConstructor(String.class);
-                   thisServerThrowable = (Throwable) xCon.newInstance(new Object[] { x.logMsg });
-
-               } catch (NoSuchMethodException e) {
-                   try {
-                       // We could use a null cause
-                       xCon = clazz.getConstructor(String.class, Throwable.class);
-                       thisServerThrowable = (Throwable) xCon.newInstance(new Object[] { x.logMsg, null });
-
-                   } catch (NoSuchMethodException e2) {
-                       try {
-                           // We could even embed the log line via a fake cause:
-                           // throwable.initCause(new RuntimeException(message))
-                           xCon = clazz.getConstructor();
-                           thisServerThrowable = (Throwable) xCon.newInstance();
-                           thisServerThrowable.initCause(new RuntimeException(x.logMsg));
-
-                       } catch (NoSuchMethodException e3) {
-                           log.warning("Arquillian container could not load external Throwable 1, from: " + x);
-                           thisServerThrowable = new UnloadableLogError(x.logMsg);
-                       }
-                   }
-               }
-           } else { // Cause is not null
-               try {
-                   // Ideally we want to add the FFDC log line
-                   xCon = clazz.getConstructor(String.class, Throwable.class);
-                   thisServerThrowable = (Throwable) xCon.newInstance(new Object[] { x.logMsg, cause });
-
-               } catch (NoSuchMethodException e) {
-                   try {
-                       // Some 'old' errors can add the cause afterwards
-                       xCon = clazz.getConstructor(String.class);
-                       thisServerThrowable = (Throwable) xCon.newInstance(new Object[] { x.logMsg });
-                       thisServerThrowable.initCause(cause);
-
-                   } catch (NoSuchMethodException e2) {
-                       try {
-                           // We are prepared to loose the log line to get the correct exception
-                           xCon = clazz.getConstructor(Throwable.class);
-                           thisServerThrowable = (Throwable) xCon.newInstance(new Object[] { cause });
-
-                       } catch (NoSuchMethodException e3) {
-                           // We could not get the right result;
-                           log.warning("Arquillian container could not load external Throwable 2, from: " + x);
-                           thisServerThrowable = new UnloadableLogError(x.logMsg, cause);
-                       }
-                   }
-               }
-
-           }
-
-       } catch (InstantiationException e) {
-           log.warning(e.toString() + "Arquillian container could not load external Throwable 3, from: " + x);
-       } catch (IllegalAccessException e) {
-           log.warning(e.toString() + "Arquillian container could not load external Throwable 4, from: " + x);
-       } catch (IllegalArgumentException e) {
-           log.warning(e.toString() + "Arquillian container could not load external Throwable 5, from: " + x);
-       } catch (InvocationTargetException e) {
-           log.warning(e.toString() + "Arquillian container could not load external Throwable 6, from: " + x);
-       }
-
-       if (thisServerThrowable == null) {
-           thisServerThrowable = new UnloadableLogError(x.logMsg, cause);
-       }
-
-       log.finest("Actually created class= " + thisServerThrowable.getClass().getName() + " instance msg="
-               + thisServerThrowable.getMessage());
-
-       return thisServerThrowable;
-   }
-
-   /**
-    * Get a list of ExMsg objects representing Exceptions in a FFDC log file
-    * 
-    * @param ffdc
-    *            the ffdc file being processed
-    * @return an ordered list of exceptions, as ExMsg, foundß
-    */
-   private ArrayList<ExMsg> getExceptionCausalChain(File ffdc) {
-
-       ArrayList<ExMsg> result = new ArrayList<ExMsg>();
-
-       BufferedReader br = null;
-       try {
-           br = new BufferedReader(new InputStreamReader(new FileInputStream(ffdc)));
-           String line;
-           // FFDC files have the form:
-           // Stack Dump = com.ibm.ws.container.service.state.StateChangeException:
-           // Caused by: org.jboss.weld.exceptions.WeldException:
-           // Caused by: org.jboss.weld.exceptions.DefinitionException:
-
-           while ((line = br.readLine()) != null) {
-               Pattern p = Pattern.compile("(Stack Dump = |Caused by: )([\\p{L}\\p{N}_$\\.]+?):(.*)");
-
-               Matcher m = p.matcher(line);
-               if (m.matches()) {
-                   ExMsg x = new ExMsg();
-                   x.exName = m.group(2);
-                   x.logMsg = line;
-                   log.finest("match on line: " + line + " resolved to className " + x.exName);
-                   result.add(x);
-               } else {
-                   log.finest("no match found on line: " + line);
-               }
-           }
-
-       } catch (IOException e) {
-           // We are OK to return empty handed (and fail the test if needed) but will log the event...
-           log.warning("FFDC file " + ffdc!=null?ffdc.getAbsolutePath():"null" + " IO Exception: " + e.toString());
-       } finally {
-           if (br != null) {
-               try {
-                   br.close();
-               } catch (IOException e) {
-                   log.warning(e.getMessage());
-               }
-           }
-       }
-       log.finest("Exception stack found was: " + Arrays.deepToString(result.toArray()));
-       return result;
-   }
-
-   /**
-    * Find the app's StateChangeException FFDC file (using Java 6 compatible code).
-    * 
-    * @param appName
-    * @param ffdcFiles
-    * 
-    * @return The correct FFDC File or null
-    * 
-    * @throws FileNotFoundException
-    * @throws IOException
-    */
-   private File findStateChangeExceptionFfdcFileForApp(String appName, File[] ffdcFiles) {
-
-       BufferedReader br = null;
-       try {
-           for (int i = 0; i < ffdcFiles.length; i++) {
-
-               // Set up a bufferedReader
-               File ffdcFile = ffdcFiles[i];
-               log.finest("Processing FFDC file: " + ffdcFile.getAbsolutePath());
-               try {
-                   br = new BufferedReader(new InputStreamReader(new FileInputStream(ffdcFile)));
-               } catch (FileNotFoundException e) {
-                   log.warning("File " + ffdcFile.getAbsolutePath() + " is no longer accessible");
-                   continue; // File has been deleted but it might not have been the target one
-               }
-
-               // See if it fulfills the criteria
-               try {
-
-                   boolean fileIsForStateChangeException = false;
-                   boolean fileIsForCorrectApplication = false;
-
-                   String line;
-                   while ((line = br.readLine()) != null) {
-
-                       fileIsForStateChangeException = fileIsForStateChangeException || line
-                               .contains("Stack Dump = com.ibm.ws.container.service.state.StateChangeException");
-                       log.finest("fileIsForStateChangeException:" + fileIsForStateChangeException + " " + line);
-
-                       fileIsForCorrectApplication = fileIsForCorrectApplication
-                               || line.contains("appName") && line.contains(appName);
-                       log.finest("fileIsForCorrectApplication:" + fileIsForCorrectApplication + "(" + appName + ")"
-                               + " " + line);
-
-                       // Have we found all the criteria we are looking for?
-                       if (fileIsForStateChangeException && fileIsForCorrectApplication) {
-                           // We have found what we are looking for
-                           log.finest("Found StateChangeExceptionFfdc for " + appName + ": "
-                                   + ffdcFile.getAbsolutePath());
-                           return ffdcFile;
-                       }
-
-                   }
-                   log.finest("Did not find StateChangeExceptionFfdc for " + appName + ": "
-                           + ffdcFile.getAbsolutePath() + "(file was scanned completely)");
-
-               } catch (IOException e) {
-                   log.warning("File " + ffdcFile.getAbsolutePath() + " is not readable");
-                   continue; // File has perhaps deleted but not necessarily a disaster if we find what we
-                             // need later
-               }
-           }
-
-       } finally {
-           if (br != null) {
-               try {
-                   br.close();
-               } catch (IOException e) {
-                   log.warning(e.getMessage());
-               }
-           }
-       }
-
-       // We did not find what we are looking for
-       log.finest("No StateChangeExceptionFfdc for " + appName + " was found ");
-       return null;
-   }
-
-   /**
-    * Get the set of FFDC files, we are only called when we are expecting to see
-    * some FFDC's so we will loop, waiting for 1/100th of a second and up to 10
-    * seconds until we see at least on FFDC. Normally we will not have to wait at
-    * all.
-    * 
-    * @return an array of File from the FFDC dir that start "ffdc_"
-    * @throws IOException
-    */
-   private File[] getFfdcFilesSince(Long deployTime) {
-
-       // We want to look for all FFDCs from at least 1 second before deploy until
-       // now...
-       final long AT_LEAST_ONE_SECOND = (1 * 1000) + 1;
-       // Perhaps we have not passed in the deploy time - if so scan all FFDCs:
-       final long since = deployTime != null ? (deployTime - AT_LEAST_ONE_SECOND) : 0;
-       File[] ffdcFiles = null;
-
-       int attempts = 0;
-       do {
-           try {
-               Thread.sleep(100);
-           } catch (InterruptedException e1) {
-               // do nothing
-           }
-           File ffdcDir = null;
-           String ffdcDirPath = "NOT_SET";
-           try {
-               ffdcDirPath = getLogsDirectory() + "/ffdc";
-               ffdcDir = new File(ffdcDirPath);
-           } catch (IOException e) {
-               log.warning("FFDC path : " + ffdcDirPath + " not (yet?) openable as new File");
-               continue;
-           }
-           log.finest(
-                   "FFDC Dir: " + ffdcDir.getAbsolutePath() + "looking for ffdc_* file since " + new Timestamp(since));
-           ffdcFiles = ffdcDir.listFiles(new FilenameFilter() {
-               public boolean accept(File dir, String fileName) {
-                   File ffdcFile = new File(dir, fileName);
-                   return (ffdcFile.lastModified() >= since) && fileName.startsWith("ffdc_");
-               }
-           });
-           attempts++;
-           log.finest("FFDC files are: " + Arrays.toString(ffdcFiles));
-
-       } while ((ffdcFiles == null || ffdcFiles.length == 0) && attempts <= 100);
-
-       return ffdcFiles;
-   }
-
    /**
     * Do System.getenv under a doPrivileged
     * @param name
@@ -1944,38 +1575,6 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
            }
        }
 
-   }
-   
-   /*
-    * When we can't find/load a class from what we think is the
-    * exception name we use a generic wrapper to allow us to
-    * see the log line later
-    */
-   public class UnloadableLogError extends RuntimeException {
-       private static final long serialVersionUID = 1L;
-       private String logLine;
-       private Throwable cause;
-       
-       public UnloadableLogError(String logLine){
-           this.logLine=logLine;
-       }
-       public UnloadableLogError(String logLine, Throwable cause){
-           super(logLine, cause);
-           this.logLine=logLine;
-           this.cause = cause;
-       }
-       
-   }
-
-   /**
-    * Small class the hold an potential nested exception
-    */
-   private class ExMsg {
-       String exName;
-       String logMsg;
-       public String toString(){
-           return exName + "(" + logMsg + ")";
-       }
    }
 
 }

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/CDILogExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/CDILogExceptionLocator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.exceptions;
+
+import java.util.logging.Logger;
+
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.enterprise.inject.spi.DeploymentException;
+
+/**
+ * This is old code to determine CDI exceptions from log lines
+ */
+public class CDILogExceptionLocator implements DeploymentExceptionLocator {
+    
+    private static Logger log = Logger.getLogger(CDILogExceptionLocator.class.getName());
+
+    @Override
+    public Throwable getException(String appName, String logLine, long deploymentTime) {
+        if (logLine.contains("DefinitionException")) {
+            log.finest("DefinitionException found in line" + logLine);
+            return new DefinitionException(logLine);
+         } else if (logLine.contains("DeploymentException") ||
+                 logLine.contains("InconsistentSpecializationException") ||
+                 logLine.contains("UnserializableDependencyException")) {
+            /*
+             * The CDI specification allows an implementation to throw a subclass of
+             * javax.enterprise.inject.spi.DeploymentException. Weld has three types
+             * such exceptions:
+             *  - org.jboss.weld.exceptions.DeploymentException
+             *  - org.jboss.weld.exceptions.InconsistentSpecializationException
+             *  - org.jboss.weld.exceptions.UnserializableDependencyException
+             */
+            log.finest("DeploymentException found in line" + logLine);
+            return new DeploymentException(logLine);
+         } else {
+             return null;
+         }
+    }
+
+}

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/CDILogExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/CDILogExceptionLocator.java
@@ -29,7 +29,7 @@ public class CDILogExceptionLocator implements DeploymentExceptionLocator {
     @Override
     public Throwable getException(String appName, String logLine, long deploymentTime) {
         if (logLine.contains("DefinitionException")) {
-            log.finest("DefinitionException found in line" + logLine);
+            log.finest("DefinitionException found in line " + logLine);
             return new DefinitionException(logLine);
          } else if (logLine.contains("DeploymentException") ||
                  logLine.contains("InconsistentSpecializationException") ||
@@ -42,7 +42,7 @@ public class CDILogExceptionLocator implements DeploymentExceptionLocator {
              *  - org.jboss.weld.exceptions.InconsistentSpecializationException
              *  - org.jboss.weld.exceptions.UnserializableDependencyException
              */
-            log.finest("DeploymentException found in line" + logLine);
+            log.finest("DeploymentException found in line " + logLine);
             return new DeploymentException(logLine);
          } else {
              return null;

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/DeploymentExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/DeploymentExceptionLocator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.exceptions;
+
+public interface DeploymentExceptionLocator {
+    
+    /**
+     * Return the exception that caused the most recently deployed application not to start
+     * 
+     * @param appName the name of the application
+     * @param logLine the deployment failure line from the log
+     * @param deploymentTime the time in ms since the epoch that the application was deployed, can be used to limit the time to search
+     * @return the exception that caused the deployment failure
+     */
+    public Throwable getException(String appName, String logLine, long deploymentTime);
+
+}

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/FFDCExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/FFDCExceptionLocator.java
@@ -215,7 +215,7 @@ public class FFDCExceptionLocator implements DeploymentExceptionLocator {
             // Caused by: org.jboss.weld.exceptions.DefinitionException:
 
             while ((line = br.readLine()) != null) {
-                Pattern p = Pattern.compile("(Stack Dump = |Caused by: )([\\p{L}\\p{N}_$\\.]+?):(.*)");
+                Pattern p = Pattern.compile("(Stack Dump = |Caused by: )([\\p{L}\\p{N}_$\\.]+?)(:|$)(.*)");
 
                 Matcher m = p.matcher(line);
                 if (m.matches()) {

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/FFDCExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/FFDCExceptionLocator.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.exceptions;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.openliberty.arquillian.managed.exceptions.NestedExceptionBuilder.ExMsg;
+
+/**
+ * Finds deployment exceptions by reading FFDC files
+ */
+public class FFDCExceptionLocator implements DeploymentExceptionLocator {
+
+    private static Logger log = Logger.getLogger(FFDCExceptionLocator.class.getName());
+
+    private final String logsDirectory;
+    
+    public FFDCExceptionLocator(String logsDirectory) {
+        this.logsDirectory = logsDirectory;
+    }
+
+    @Override
+    public Throwable getException(String appName, String logLine, long deploymentTime) {
+        // Get the set of ffdc files
+        File[] ffdcFiles = getFfdcFilesSince(deploymentTime);
+
+        // Get StateChangeException FFDC file for this application
+        File ffdc = findStateChangeExceptionFfdcFileForApp(appName, ffdcFiles);
+
+        Throwable cause = null;
+
+        if (ffdc != null) {
+            // Get StateChangeException ffdc exception names and info chain
+            ArrayList<ExMsg> chain = getExceptionCausalChain(ffdc);
+
+            if (chain != null) {
+                cause = NestedExceptionBuilder.buildNestedException(chain);
+            }
+        }
+
+        for (Throwable c = cause; c != null; c = c.getCause()) {
+            log.finest("FFDC Exception Chain:" + c.getClass());
+        }
+
+        return cause;
+    }
+
+    /**
+     * Get the set of FFDC files, we are only called when we are expecting to see
+     * some FFDC's so we will loop, waiting for 1/100th of a second and up to 10
+     * seconds until we see at least on FFDC. Normally we will not have to wait at
+     * all.
+     * 
+     * @return an array of File from the FFDC dir that start "ffdc_"
+     * @throws IOException
+     */
+    private File[] getFfdcFilesSince(Long deployTime) {
+
+        // We want to look for all FFDCs from at least 1 second before deploy until
+        // now...
+        final long AT_LEAST_ONE_SECOND = (1 * 1000) + 1;
+        // Perhaps we have not passed in the deploy time - if so scan all FFDCs:
+        final long since = deployTime != null ? (deployTime - AT_LEAST_ONE_SECOND) : 0;
+        File[] ffdcFiles = null;
+
+        int attempts = 0;
+        do {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e1) {
+                // do nothing
+            }
+            File ffdcDir = null;
+            String ffdcDirPath = "NOT_SET";
+            ffdcDirPath = logsDirectory + "/ffdc";
+            ffdcDir = new File(ffdcDirPath);
+            log.finest(
+                       "FFDC Dir: " + ffdcDir.getAbsolutePath() + "looking for ffdc_* file since "
+                               + new Timestamp(since));
+            ffdcFiles = ffdcDir.listFiles(new FilenameFilter() {
+                public boolean accept(File dir, String fileName) {
+                    File ffdcFile = new File(dir, fileName);
+                    return (ffdcFile.lastModified() >= since) && fileName.startsWith("ffdc_");
+                }
+            });
+            attempts++;
+            log.finest("FFDC files are: " + Arrays.toString(ffdcFiles));
+
+        } while ((ffdcFiles == null || ffdcFiles.length == 0) && attempts <= 100);
+
+        return ffdcFiles;
+    }
+
+    /**
+     * Find the app's StateChangeException FFDC file (using Java 6 compatible code).
+     * 
+     * @param appName
+     * @param ffdcFiles
+     * 
+     * @return The correct FFDC File or null
+     * 
+     * @throws FileNotFoundException
+     * @throws IOException
+     */
+    private File findStateChangeExceptionFfdcFileForApp(String appName, File[] ffdcFiles) {
+
+        BufferedReader br = null;
+        try {
+            for (int i = 0; i < ffdcFiles.length; i++) {
+
+                // Set up a bufferedReader
+                File ffdcFile = ffdcFiles[i];
+                log.finest("Processing FFDC file: " + ffdcFile.getAbsolutePath());
+                try {
+                    br = new BufferedReader(new InputStreamReader(new FileInputStream(ffdcFile)));
+                } catch (FileNotFoundException e) {
+                    log.warning("File " + ffdcFile.getAbsolutePath() + " is no longer accessible");
+                    continue; // File has been deleted but it might not have been the target one
+                }
+
+                // See if it fulfills the criteria
+                try {
+
+                    boolean fileIsForStateChangeException = false;
+                    boolean fileIsForCorrectApplication = false;
+
+                    String line;
+                    while ((line = br.readLine()) != null) {
+
+                        fileIsForStateChangeException = fileIsForStateChangeException || line
+                                .contains("Stack Dump = com.ibm.ws.container.service.state.StateChangeException");
+                        log.finest("fileIsForStateChangeException:" + fileIsForStateChangeException + " " + line);
+
+                        fileIsForCorrectApplication = fileIsForCorrectApplication
+                                || line.contains("appName") && line.contains(appName);
+                        log.finest("fileIsForCorrectApplication:" + fileIsForCorrectApplication + "(" + appName + ")"
+                                + " " + line);
+
+                        // Have we found all the criteria we are looking for?
+                        if (fileIsForStateChangeException && fileIsForCorrectApplication) {
+                            // We have found what we are looking for
+                            log.finest("Found StateChangeExceptionFfdc for " + appName + ": "
+                                    + ffdcFile.getAbsolutePath());
+                            return ffdcFile;
+                        }
+
+                    }
+                    log.finest("Did not find StateChangeExceptionFfdc for " + appName + ": "
+                            + ffdcFile.getAbsolutePath() + "(file was scanned completely)");
+
+                } catch (IOException e) {
+                    log.warning("File " + ffdcFile.getAbsolutePath() + " is not readable");
+                    continue; // File has perhaps deleted but not necessarily a disaster if we find what we
+                              // need later
+                }
+            }
+
+        } finally {
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (IOException e) {
+                    log.warning(e.getMessage());
+                }
+            }
+        }
+
+        // We did not find what we are looking for
+        log.finest("No StateChangeExceptionFfdc for " + appName + " was found ");
+        return null;
+    }
+
+    /**
+     * Get a list of ExMsg objects representing Exceptions in a FFDC log file
+     * 
+     * @param ffdc
+     *            the ffdc file being processed
+     * @return an ordered list of exceptions, as ExMsg, foundß
+     */
+    private ArrayList<ExMsg> getExceptionCausalChain(File ffdc) {
+
+        ArrayList<ExMsg> result = new ArrayList<ExMsg>();
+
+        BufferedReader br = null;
+        try {
+            br = new BufferedReader(new InputStreamReader(new FileInputStream(ffdc)));
+            String line;
+            // FFDC files have the form:
+            // Stack Dump = com.ibm.ws.container.service.state.StateChangeException:
+            // Caused by: org.jboss.weld.exceptions.WeldException:
+            // Caused by: org.jboss.weld.exceptions.DefinitionException:
+
+            while ((line = br.readLine()) != null) {
+                Pattern p = Pattern.compile("(Stack Dump = |Caused by: )([\\p{L}\\p{N}_$\\.]+?):(.*)");
+
+                Matcher m = p.matcher(line);
+                if (m.matches()) {
+                    ExMsg x = new ExMsg();
+                    x.exName = m.group(2);
+                    x.logMsg = line;
+                    log.finest("match on line: " + line + " resolved to className " + x.exName);
+                    result.add(x);
+                } else {
+                    log.finest("no match found on line: " + line);
+                }
+            }
+
+        } catch (IOException e) {
+            // We are OK to return empty handed (and fail the test if needed) but will log
+            // the event...
+            log.warning("FFDC file " + ffdc != null ? ffdc.getAbsolutePath()
+                    : "null" + " IO Exception: " + e.toString());
+        } finally {
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (IOException e) {
+                    log.warning(e.getMessage());
+                }
+            }
+        }
+        log.finest("Exception stack found was: " + Arrays.deepToString(result.toArray()));
+        return result;
+    }
+
+}

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/NestedExceptionBuilder.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/NestedExceptionBuilder.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.exceptions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Builds an exception cause chain from a list of exception class names and messages
+ * <p>
+ * This is used to turn a stack trace from the server into a chain of exceptions on the client.
+ * <p>
+ * If an exception class thrown by the server can't be loaded on the client, then it is replaced by an {@link UnloadableLogException}
+ */
+public class NestedExceptionBuilder {
+    
+    private static Logger log = Logger.getLogger(NestedExceptionBuilder.class.getName());
+    
+    /**
+     * Mapping from some known implementation classes to the API classes they extend
+     * <p>
+     * In general, it's much more likely the client has the API classes available to load
+     */
+    private final static Map<String, String> exceptionMappings = new HashMap<>();
+    static {
+        exceptionMappings.put("org.jboss.weld.exceptions.DeploymentException", "javax.enterprise.inject.spi.DeploymentException");
+        exceptionMappings.put("org.jboss.weld.exceptions.InconsistentSpecializationException", "javax.enterprise.inject.spi.DeploymentException");
+        exceptionMappings.put("org.jboss.weld.exceptions.UnserializableDependencyException", "javax.enterprise.inject.spi.DeploymentException");
+        exceptionMappings.put("org.jboss.weld.exceptions.DefinitionException", "javax.enterprise.inject.spi.DefinitionException");
+    }
+    
+    /**
+     * Small class the hold an potential nested exception
+     */
+    public static class ExMsg {
+        String exName;
+        String logMsg;
+        public String toString(){
+            return exName + "(" + logMsg + ")";
+        }
+    }
+    
+    /**
+     * When we can't find/load a class from what we think is the
+     * exception name we use a generic wrapper to allow us to
+     * see the log line later
+     */
+    public static class UnloadableLogException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        
+        public UnloadableLogException(String logLine){
+            super(logLine);
+        }
+        
+        public UnloadableLogException(String logLine, Throwable cause){
+            super(logLine, cause);
+        }
+        
+    }
+    
+    
+    /**
+     * Create and return the nested FFDC exception chain as a Throwable with
+     * cause(s)
+     * 
+     * @param exs
+     *            - an ordered list of the Exception log messages
+     * @return a Throwable with usable causal chain
+     */
+    public static Throwable buildNestedException(ArrayList<ExMsg> exs) {
+
+        Throwable causeSoFar = null;
+
+        for (int nestLevel = exs.size() - 1; nestLevel >= 0; nestLevel--) {
+            causeSoFar = createException(exs.get(nestLevel), causeSoFar);
+        }
+
+        return causeSoFar;
+    }
+
+    /**
+     * Turn a FFDC log line into a Throwable object. This depends on Class.forname
+     * loading so maven pom dependencies need to include classes that need to be
+     * loaded on the classpath
+     * 
+     * @param x - the exception message object
+     * @param cause - something to nest inside the Throwable we create - can be null
+     * @return - a non-null Throwable that reflects the log Line as well as
+     *           possible. Note that fully 'private' classes are unlikely to be in
+     *           tests' @ShouldThrow tests anyway - so in that case the important 
+     *           thing is to not break the causal chain with this link. 
+     *           We may have private subclasses of public Exceptions - we don't handle, 
+     *           but these should be treated as special cases, handled elsewhere - for
+     *           example with a service loaded DeploymentExceptionTransformer.
+     */
+    private static Throwable createException(ExMsg x, Throwable cause) {
+        
+        Throwable t = attemptCreation(x.exName, x.logMsg, cause);
+        
+        if (t == null) {
+            // If we couldn't load the actual class, check if it's a known name that we can map to an API exception class
+            String mappedExName = exceptionMappings.get(x.exName);
+            if (mappedExName != null) {
+                t = attemptCreation(mappedExName, x.logMsg, cause);
+            }
+        }
+        
+        if (t == null) {
+            log.warning("Unable to create an object for " + x.exName + ", falling back to UnloadableLogException");
+            t = new UnloadableLogException("<" + x.exName + "> " + x.logMsg, cause);
+        }
+        
+        log.finest("Actually created class= " + t.getClass().getName() + " instance msg="
+                + t.getMessage());
+        
+        return t;
+    }
+    
+    /**
+     * Attempt to create an exception instance
+     * 
+     * @param className the exception class name
+     * @param message the exception message
+     * @param cause the exception cause
+     * @return the exception, or null if it could not be created
+     */
+    private static Throwable attemptCreation(String className, String message, Throwable cause) {
+        Class<? extends Throwable> clazz = null;
+
+        // First, attempt to load the exception class thrown on the server
+        // There will be lots of cases where this isn't possible
+        try {
+            clazz = loadThrowable(className);
+        } catch (ClassNotFoundException e) {
+            log.fine("Unable to load class " + className + ": " + e);
+            return null;
+        }
+        
+        Throwable t = null;
+        
+        if (cause == null) {
+            // No cause, just a message
+            t = attemptConstruction(clazz, message);
+            
+            if (t == null) {
+                // Can also try with a message and a null cause
+                t = attemptConstruction(clazz, message, null);
+            }
+        } else {
+            // Cause and message
+            t = attemptConstruction(clazz, message, cause);
+            
+            if (t == null) {
+                // Some old exceptions construct with just a string and then initialise the cause
+                t = attemptConstructionAndInit(clazz, message, cause);
+            }
+            
+            if (t == null) {
+                // Worst case, drop the message and just include the cause
+                // Arquillian only matches on the exception class anyway
+                t = attemptConstruction(clazz, cause);
+            }
+        }
+        
+        if (t == null) {
+            log.fine("Unable to construct an instance of " + className);
+        }
+        
+        return t;
+    }
+    
+    /**
+     * Attempt to get the Class object for a named Throwable
+     * 
+     * @param name the class name
+     * @return the Class
+     * @throws ClassNotFoundException if the class could not be loaded, or if it was loaded but was not a throwable
+     */
+    private static Class<? extends Throwable> loadThrowable(String name) throws ClassNotFoundException {
+        try {
+            Class<?> clazz = Class.forName(name);
+            return clazz.asSubclass(Throwable.class);
+        } catch (ClassNotFoundException e) {
+            throw e;
+        } catch (ClassCastException e) {
+            throw new ClassNotFoundException("Loaded " + name + " successfully but it isn't a Throwable", e);
+        } catch (Exception e) {
+            throw new ClassNotFoundException("Unable to load " + name + " due to " + e, e);
+        }
+    }
+    
+    /**
+     * Attempt to create an instance by calling its (String) constructor
+     * @return the created instance, or null if it could not be created
+     */
+    private static Throwable attemptConstruction(Class<? extends Throwable> clazz, String msg) {
+        try {
+            return clazz.getConstructor(String.class).newInstance(new Object[] { msg });
+        } catch (Exception e) {
+            log.finer("Arquillian container could not construct " + clazz.getName() + "(String): " + e);
+            return null;
+        }
+    }
+    
+    /**
+     * Attempt to create an instance by calling its (String, Throwable) constructor
+     * @return the created instance, or null if it could not be created
+     */
+    private static Throwable attemptConstruction(Class<? extends Throwable> clazz, String msg, Throwable cause) {
+        try {
+            return clazz.getConstructor(String.class, Throwable.class).newInstance(new Object[] { msg, cause });
+        } catch (Exception e) {
+            log.finer("Arquillian container could not construct " + clazz.getName() + "(String, Throwable): " + e);
+            return null;
+        }
+    }
+    
+    /**
+     * Attempt to create an instance by calling its (String) constructor and then calling initCause(cause)
+     * @return the created instance, or null if it could not be created
+     */
+    private static Throwable attemptConstructionAndInit(Class<? extends Throwable> clazz, String msg, Throwable cause) {
+        try {
+            Throwable t = clazz.getConstructor(String.class).newInstance(new Object[] { msg });
+            t.initCause(cause);
+            return t;
+        } catch (Exception e) {
+            log.finer("Arquillian container could not construct " + clazz.getName() + "(String) and invoke initCause(): " + e);
+            return null;
+        }
+    }
+    
+    /**
+     * Attempt to create an instance by calling its (Throwable) constructor
+     * @return the created instance, or null if it could not be created
+     */
+    private static Throwable attemptConstruction(Class<? extends Throwable> clazz, Throwable cause) {
+        try {
+            return clazz.getConstructor(Throwable.class).newInstance(new Object[] { cause });
+        } catch (Exception e) {
+            log.finer("Arquillian container could not construct " + clazz.getName() + "(Throwable): " + e);
+            return null;
+        }
+    }
+}

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/NestedExceptionBuilder.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/NestedExceptionBuilder.java
@@ -160,6 +160,11 @@ public class NestedExceptionBuilder {
                 // Can also try with a message and a null cause
                 t = attemptConstruction(clazz, message, null);
             }
+            
+            if (t == null) {
+                // Final option, try the no-arg constructor
+                t = attemptConstruction(clazz);
+            }
         } else {
             // Cause and message
             t = attemptConstruction(clazz, message, cause);
@@ -253,6 +258,15 @@ public class NestedExceptionBuilder {
             return clazz.getConstructor(Throwable.class).newInstance(new Object[] { cause });
         } catch (Exception e) {
             log.finer("Arquillian container could not construct " + clazz.getName() + "(Throwable): " + e);
+            return null;
+        }
+    }
+    
+    private static Throwable attemptConstruction(Class<? extends Throwable> clazz) {
+        try {
+            return clazz.getConstructor().newInstance();
+        } catch (Exception e) {
+            log.finer("Arquillian container could not construct " + clazz.getName() + "(): " + e);
             return null;
         }
     }

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.exceptions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.logging.Logger;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.utils.URIBuilder;
+
+/**
+ * Tries to receive a serialized exception from the server
+ * <p>
+ * This relies on the liberty-support-feature being installed and running
+ * <p>
+ * This is the best way to get the exception as it retains all of the exception
+ * information from the server, including the stack trace, but will fail if any
+ * of the serialized classes can't be loaded on the client
+ */
+public class SupportFeatureSerializedExceptionLocator implements DeploymentExceptionLocator {
+    
+    private final static Logger log = Logger.getLogger(SupportFeatureSerializedExceptionLocator.class.getName());
+    
+    private final URI uri;
+    
+    public SupportFeatureSerializedExceptionLocator(String host, int port) {
+        try {
+            uri = new URI("http", null, host, port, "/arquillian-support/deployment-exception", "format=serialize", null);
+        } catch (URISyntaxException e) {
+            // Shouldn't happen as most of the URI parts are hard coded
+            throw new IllegalArgumentException("Invalid URI: " + e, e);
+        }
+    }
+
+    @Override
+    public Throwable getException(String appName, String logLine, long deploymentTime) {
+        Throwable result = null;
+        try {
+            URIBuilder uriBuilder = new URIBuilder(uri);
+            uriBuilder.addParameter("appName", appName);
+            
+            HttpResponse resp = Request.Get(uriBuilder.build()).execute().returnResponse();
+            if (resp.getStatusLine().getStatusCode() == 400) {
+                log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
+            } else if (resp.getStatusLine().getStatusCode() != 200) {
+                log.info("Unable to recieve serialized exception from server, is usr:arquillian-support-1.0 installed?");
+            } else {
+                try (InputStream inStream = resp.getEntity().getContent()) {
+                    ObjectInputStream objStream = new ObjectInputStream(inStream);
+                    Object readObject = objStream.readObject();
+                    if (readObject instanceof Throwable) {
+                        result = (Throwable) readObject;
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            log.warning("IO Exception trying to get serialized exception: " + ex);
+        } catch (ClassNotFoundException ex) {
+            log.finer("Unable to find class for serialized exception: " + ex);
+        } catch (Exception ex) {
+            log.warning("Unexpected exception while trying to recieve serialized exception: " + ex);
+        }
+        
+        return result;
+    }
+
+}

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.exceptions;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.utils.URIBuilder;
+
+import io.openliberty.arquillian.managed.exceptions.NestedExceptionBuilder.ExMsg;
+
+/**
+ * Tries to receive information about an exception from the server in text form
+ * <p>
+ * This relies on the liberty-support-feature being installed and running
+ * <p>
+ * The text format expected from the server includes information about the
+ * exception and its cause chain.
+ * <p>
+ * For each exception in the cause chain, the following information is returned:
+ * <ul>
+ * <li>the class name</li>
+ * <li>the names of all superclasses (if any)</li>
+ * <li>the exception message</li>
+ * </ul>
+ * <p>
+ * Example:
+ * 
+ * <pre>
+ * <code>
+ * exClass com.example.Exception
+ * exSuperclass com.example.SuperclassOfException
+ * exSuperclass com.example.SuperclassOfSuperclassOfException
+ * This is the exception message
+ * which can have multiple lines
+ * exClass com.example.CauseOfException
+ * Exception cause message
+ * ...
+ * </code>
+ * </pre>
+ * <p>
+ * This strategy for retrieving exceptions does not retain as much information
+ * as retrieving a serialized object (in particular the stack trace is lost) but
+ * it's much more robust against missing classes on the client. If one class in
+ * the cause chain can't be loaded, other classes in the chain can still be
+ * loaded. In addition, if a class in can't be loaded, we also attempt to load
+ * classes in its type hierarchy instead. This should catch most cases where a
+ * test requires that a spec exception is thrown but liberty throws an exception
+ * which subclasses it. The subclass may not be available to the client but the
+ * spec exception must be (since it was referenced from the test).
+ * 
+ */
+public class SupportFeatureTextExceptionLocator implements DeploymentExceptionLocator {
+
+    private final static Logger log = Logger.getLogger(SupportFeatureTextExceptionLocator.class.getName());
+    
+    private final URI uri;
+    
+    private static final Pattern CLASS_PATTERN = Pattern.compile("exClass (.*)");
+    private static final Pattern SUPERCLASS_PATTERN = Pattern.compile("exSuperclass (.*)");
+    
+    public SupportFeatureTextExceptionLocator(String host, int port) {
+        try {
+            uri = new URI("http", null, host, port, "/arquillian-support/deployment-exception", "format=text", null);
+        } catch (URISyntaxException e) {
+            // Shouldn't happen as most of the URI parts are hard coded
+            throw new IllegalArgumentException("Invalid URI: " + e, e);
+        }
+    }
+
+    
+    @Override
+    public Throwable getException(String appName, String logLine, long deploymentTime) {
+        try {
+            URIBuilder uriBuilder = new URIBuilder(uri);
+            uriBuilder.addParameter("appName", appName);
+            
+            HttpResponse resp = Request.Get(uriBuilder.build()).execute().returnResponse();
+            if (resp.getStatusLine().getStatusCode() == 400) {
+                log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
+            } else if (resp.getStatusLine().getStatusCode() != 200) {
+                log.info("Unable to recieve text format exception from server, is usr:arquillian-support-1.0?");
+            } else {
+                log.finer("Reading exception returned from server");
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(resp.getEntity().getContent(), StandardCharsets.UTF_8))) {
+                    return readResponse(reader);
+                }
+            }
+        } catch (IOException ex) {
+            log.warning("IO Exception trying to get text exception: " + ex);
+        } catch (Exception ex) {
+            log.warning("Unexpected exception thrown while trying to get text exception: " + ex);
+        }
+        
+        return null;
+    }
+    
+    private Throwable readResponse(BufferedReader reader) throws IOException {
+        String line;
+        ResponseReader responseReader = new ResponseReader();
+        while ((line = reader.readLine()) != null) {
+            Matcher classMatcher = CLASS_PATTERN.matcher(line);
+            if (classMatcher.matches()) {
+                responseReader.readClass(classMatcher.group(1));
+                continue;
+            }
+            
+            Matcher superclassMatcher = SUPERCLASS_PATTERN.matcher(line);
+            if (superclassMatcher.matches()) {
+                responseReader.readSuperclass(superclassMatcher.group(1));
+                continue;
+            }
+            
+            responseReader.readMessage(line);
+        }
+        responseReader.finishMsg();
+        List<ExMsg> msgs = responseReader.finish();
+        
+        return NestedExceptionBuilder.buildNestedException(msgs);
+    }
+    
+    private static class ResponseReader {
+        List<ExMsg> msgs = new ArrayList<>();
+        ExMsg currentMsg = null;
+        StringBuilder messageBuilder = null;
+        
+        private void readClass(String className) {
+            log.finer("Read class " + className);
+            finishMsg();
+            currentMsg.exName = className;
+        }
+        
+        private void readSuperclass(String className) {
+            log.finer("Read superclass" + className);
+            currentMsg.superclasses.add(className);
+        }
+        
+        private void readMessage(String message) {
+            log.finer("Read message " + message);
+            if (messageBuilder == null) {
+                messageBuilder = new StringBuilder();
+            } else {
+                messageBuilder.append("\n");
+            }
+            messageBuilder.append(message);
+        }
+        
+        private void finishMsg() {
+            if (currentMsg != null) {
+                msgs.add(currentMsg);
+                if (messageBuilder != null) {
+                    currentMsg.logMsg = messageBuilder.toString();
+                }
+            }
+            currentMsg = new ExMsg();
+            messageBuilder = null;
+        }
+        
+        private List<ExMsg> finish() {
+            return msgs;
+        }
+    }
+
+}

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/package-info.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes for determining the cause when an application fails to deploy
+ */
+package io.openliberty.arquillian.managed.exceptions;

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
@@ -30,7 +30,6 @@ public class WLPResourceTestCase {
     @Test
     public void serverEnvironmentVariablesShouldBeSet(){
         Assert.assertNotNull(System.getenv("foo"));
-        Assert.assertNotNull(System.getenv("WLP_SKIP_MAXPERMSIZE"));
         Assert.assertNotNull(System.getenv("keystore_password"));
     }
 

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/StartupFailureExtension.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/StartupFailureExtension.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.needssupportfeature.deploymentfailure;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+/**
+ * Causes a definition error by throwing a TestAppException during startup
+ */
+public class StartupFailureExtension implements Extension {
+
+    public void crashIt(@Observes ProcessAnnotatedType<?> bbd) {
+        throw new TestAppException("");
+    }
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/TestAppException.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/TestAppException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.needssupportfeature.deploymentfailure;
+
+public class TestAppException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TestAppException(String message) {
+        super(message);
+    }
+
+}

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/WLPDeploymentExceptionTest.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/WLPDeploymentExceptionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.managed.needssupportfeature.deploymentfailure;
+
+import static org.junit.Assert.fail;
+
+import javax.enterprise.inject.spi.Extension;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class WLPDeploymentExceptionTest {
+    
+    public static final String INVALID_APP = "invalidApp";
+
+    @Deployment(name = INVALID_APP, managed = false)
+    public static WebArchive buildInvalidApp() {
+        
+        WebArchive war = ShrinkWrap.create(WebArchive.class)
+                                   .addPackage(WLPDeploymentExceptionTest.class.getPackage())
+                                   .addAsServiceProvider(Extension.class, StartupFailureExtension.class)
+                                   .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        return war;
+    }
+    
+    @ArquillianResource
+    Deployer deployer;
+    
+    /**
+     * Deploy the invalid app repeatedly to ensure that it throws the correct deployment error every time
+     */
+    @Test
+    public void testDeploymentErrors() {
+        for (int i = 0; i < 15; i++) {
+            try {
+                deployer.deploy(INVALID_APP);
+                fail("App deployed successfully");
+            } catch (Exception ex) {
+                assertExceptionInCauseChain("Incorrect exception on deployment " + i, ex, TestAppException.class);
+            } finally {
+                deployer.undeploy(INVALID_APP);
+            }
+        }
+    }
+
+    private void assertExceptionInCauseChain(String message, Throwable ex, Class<? extends Throwable> expectedExceptionClass) {
+        Throwable currentCause = ex;
+        while (currentCause != null) {
+            if (expectedExceptionClass.isInstance(currentCause)) {
+                return;
+            }
+            currentCause = currentCause.getCause();
+        }
+        throw new AssertionError(message + ": Exception cause chain did not include an instance of " + expectedExceptionClass, ex);
+    }
+
+}

--- a/liberty-managed/src/test/resources/server-with-management.xml
+++ b/liberty-managed/src/test/resources/server-with-management.xml
@@ -8,6 +8,7 @@
         <feature>cdi-1.2</feature>
         <feature>j2eeManagement-1.1</feature>
         <feature>jndi-1.0</feature>
+        <feature>usr:arquillian-support-1.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 

--- a/liberty-managed/src/test/resources/server.env
+++ b/liberty-managed/src/test/resources/server.env
@@ -1,3 +1,2 @@
 keystore_password=LO4ZKcuZJZFzgpFTaDjzW21
-WLP_SKIP_MAXPERMSIZE=true
 foo=bar

--- a/liberty-support-feature/README.md
+++ b/liberty-support-feature/README.md
@@ -1,0 +1,46 @@
+# Arquillian support Liberty user feature
+
+A liberty user feature which allows deployment exceptions to be reported more reliably when using the liberty-managed container
+
+The arquillian support feature adds an additional http endpoint which the arquillian container can query to determine the cause when an application fails to start.
+
+It is only for supporting the running of arquillian tests and must not be installed on a production system.
+
+## Usage
+
+1. Extract the arquillian-liberty-support-x.x.x-feature.zip into the `usr` directory of your liberty runtime
+1. Add `<feature>usr:arquillian-support-1.0</feature>` to the `<featureManager>` section of your `server.xml`
+
+## Maven usage
+
+You can install the arquillian-liberty-support feature as part of a maven build using the [maven-dependency-plugin:unpack goal](https://maven.apache.org/plugins/maven-dependency-plugin/unpack-mojo.html)
+
+Example:
+
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-dependency-plugin</artifactId>
+      <version>3.1.1</version>
+      <executions>
+        <execution>
+          <id>extract-support-feature</id>
+          <phase>pre-integration-test</phase>
+          <goals>
+            <goal>unpack</goal>
+          </goals>
+        </execution>
+      </executions>
+      <configuration>
+        <artifactItems>
+          <artifactItem>
+            <groupId>io.openliberty.arquillian</groupId>
+            <artifactId>arquillian-liberty-support</artifactId>
+            <version>1.0.4</version>
+            <type>zip</type>
+            <classifier>feature</classifier>
+            <overWrite>false</overWrite>
+            <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
+          </artifactItem>
+        </artifactItems>
+      </configuration>
+    </plugin>

--- a/liberty-support-feature/assembly.xml
+++ b/liberty-support-feature/assembly.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2
+      http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>feature</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/feature</directory>
+      <outputDirectory>/extension/lib/features</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory>/extension/lib</outputDirectory>
+      <includes>
+        <include>${project.build.finalName}.jar</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/liberty-support-feature/bnd.bnd
+++ b/liberty-support-feature/bnd.bnd
@@ -1,0 +1,5 @@
+Web-ContextPath: arquillian-support
+Import-Package: javax.servlet.*; version="[2.6, 3)", \
+  com.ibm.ws.container.service.app.deploy; version="[1.0, 3)", \
+  *
+Bundle-Version: ${parsedVersion.osgiVersion}

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>io.openliberty.arquillian</groupId>
+    <artifactId>arquillian-parent-liberty</artifactId>
+    <version>1.0.4-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <!-- Model Version -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Configuration -->
+  <artifactId>arquillian-liberty-support</artifactId>
+  <name>Arquillian Container Liberty Support Feature</name>
+  <description>Liberty Feature to support integration for the Arquillian Project</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-distribution</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>assembly.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/feature</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/feature/resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.containerServices</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.websphere.appserver.spi</groupId>
+      <artifactId>com.ibm.websphere.appserver.spi.logging</artifactId>
+      <version>1.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+      <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
+++ b/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
@@ -1,0 +1,11 @@
+IBM-Feature-Version: 2
+IBM-ShortName: arquillian-support-1.0
+Subsystem-Content: arquillian-liberty-support; version=${parsedVersion.osgiVersion},
+ com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
+ com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"; type="osgi.subsystem.feature"
+Subsystem-Description: Liberty Feature to support integration for the Arquillian Project
+Subsystem-ManifestVersion: 1
+Subsystem-Name: Arquillian Support Feature
+Subsystem-SymbolicName: io.openliberty.arquillian.arquillian-support-1.0; visibility:=public
+Subsystem-Type: osgi.subsystem.feature
+Subsystem-Version: ${parsedVersion.osgiVersion}

--- a/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/DeploymentExceptionServlet.java
+++ b/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/DeploymentExceptionServlet.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.support;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import io.openliberty.arquillian.support.IncidentListener.ExceptionInfo;
+
+@WebServlet("/deployment-exception")
+public class DeploymentExceptionServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private static final Set<Class<?>> topClasses = new HashSet<>();
+    static {
+        topClasses.add(Object.class);
+        topClasses.add(Throwable.class);
+        topClasses.add(Exception.class);
+        topClasses.add(Error.class);
+        topClasses.add(RuntimeException.class);
+    }
+    
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        IncidentListener listener = getIncidentListener(req);
+        
+        resp.setContentType("text/plain;charset=UTF-8");
+        ExceptionInfo ex = listener.getLastException();
+        
+        String appName = req.getParameter("appName");
+        
+        if (appName == null) {
+            resp.setStatus(400);
+            resp.getWriter().println("No appName given");
+            return;
+        }
+        
+        if (ex == null) {
+            resp.setStatus(400);
+            resp.getWriter().println("No exception logged");
+            return;
+        }
+        
+        if (!appName.equals(ex.getAppName())) {
+            resp.setStatus(400);;
+            resp.getWriter().println("Last exception was not thrown by the requested app");
+            return;
+        }
+        
+        String format = req.getParameter("format");
+        if (format == null) {
+            resp.setStatus(400);
+            resp.getWriter().println("Format parameter not set");
+        } else if (format.equals("text")) {
+            printText(resp.getWriter(), ex.getException());
+        } else if (format.equals("stack")) {
+            ex.getException().printStackTrace(resp.getWriter());
+        } else if (format.equals("serialize")) {
+            resp.setContentType("application/java-serialized-object");
+            try (ObjectOutputStream oos = new ObjectOutputStream(resp.getOutputStream())) {
+                oos.writeObject(ex.getException());
+            }
+        } else {
+            resp.setStatus(400);
+            resp.getWriter().println("Invalid format requested");
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if ("true".equalsIgnoreCase(req.getParameter("clear"))) {
+            getIncidentListener(req).clear();
+        } else {
+            throw new ServletException("Invalid command");
+        }
+    }
+
+    private IncidentListener getIncidentListener(HttpServletRequest req) {
+        ServletContext context = req.getServletContext();
+        IncidentListener listener = (IncidentListener) context.getAttribute(Initializer.INCIDENT_LISTENER_ATTRIBUTE);
+        if (listener == null) {
+            throw new RuntimeException("Incident listener is not set");
+        }
+        return listener;
+    }
+    
+    private void printText(PrintWriter resp, Throwable exception) {
+        Throwable t = exception;
+        HashSet<Throwable> processed = new HashSet<>();
+        while (t != null && !processed.contains(t)) {
+            printClass(resp, t);
+            processed.add(t);
+            t = t.getCause();
+        }
+    }
+    
+    private void printClass(PrintWriter resp, Throwable exception) {
+        resp.print("exClass ");
+        resp.print(exception.getClass().getName());
+        resp.println();
+        
+        Class<?> clazz = exception.getClass().getSuperclass();
+        while (clazz != null && !topClasses.contains(clazz)) {
+            resp.print("exSuperclass ");
+            resp.print(clazz.getName());
+            resp.println();
+            clazz = clazz.getSuperclass();
+        }
+        
+        resp.println(exception.getMessage());
+    }
+
+}

--- a/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/IncidentListener.java
+++ b/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/IncidentListener.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.support;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
+import com.ibm.ws.container.service.state.ApplicationStateListener;
+import com.ibm.ws.container.service.state.StateChangeException;
+import com.ibm.wsspi.logging.Incident;
+import com.ibm.wsspi.logging.IncidentForwarder;
+
+public class IncidentListener implements IncidentForwarder, ApplicationStateListener {
+    
+    private AtomicReference<ExceptionInfo> lastException = new AtomicReference<>();
+    private AtomicReference<String> appName = new AtomicReference<String>(null);
+
+    @Override
+    public void process(Incident incident, Throwable exception) {
+        // We always expect a state change exception if there's a failure during deployment
+        if (exception instanceof StateChangeException) {
+            ExceptionInfo info = new ExceptionInfo(exception, appName.get());
+            lastException.set(info);
+        }
+    }
+   
+    public ExceptionInfo getLastException() {
+        return lastException.get();
+    }
+    
+    public void clear() {
+        lastException.set(null);
+    }
+
+    @Override
+    public void applicationStarting(ApplicationInfo appInfo) throws StateChangeException {
+        appName.set(appInfo.getName());
+    }
+
+    @Override
+    public void applicationStarted(ApplicationInfo arg0) throws StateChangeException {
+        // Do nothing
+    }
+
+    @Override
+    public void applicationStopped(ApplicationInfo arg0) {
+        // Do nothing
+    }
+
+    @Override
+    public void applicationStopping(ApplicationInfo arg0) {
+        // Do nothing
+    }
+    
+    public static class ExceptionInfo {
+        private Throwable exception;
+        private String appName;
+        
+        public ExceptionInfo(Throwable exception, String appName) {
+            this.exception = exception;
+            this.appName = appName;
+        }
+
+        public Throwable getException() {
+            return exception;
+        }
+
+        public String getAppName() {
+            return appName;
+        }
+    }
+
+}

--- a/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/Initializer.java
+++ b/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/Initializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.support;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+
+import com.ibm.ws.container.service.state.ApplicationStateListener;
+import com.ibm.ws.ffdc.FFDC;
+
+@WebListener
+public class Initializer implements ServletContextListener {
+    
+    public static final String INCIDENT_LISTENER_ATTRIBUTE = "incident-listener";
+    public static final String BUNDLE_CONTEXT_ATTRIBUTE = "osgi-bundlecontext"; //OSGi 6.0 enterprise, 128.6.1
+    
+    private ServiceRegistration<ApplicationStateListener> appStateListenerRegistration;
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        // Register the listener as an incident forwarder
+        ServletContext context = sce.getServletContext();
+        IncidentListener listener = new IncidentListener();
+        context.setAttribute(INCIDENT_LISTENER_ATTRIBUTE, listener);
+        FFDC.registerIncidentForwarder(listener);
+        
+        // Register the listener as an ApplicationStateListener
+        BundleContext bContext = (BundleContext) context.getAttribute(BUNDLE_CONTEXT_ATTRIBUTE);
+        Dictionary<String, Object> properties = new Hashtable<>();
+        // Big number for the ranking so we get called early.
+        // Other components use this event to initialize things for the app and may throw validation exceptions,
+        // we need to know the app that's starting before an exception is thrown
+        properties.put(Constants.SERVICE_RANKING, 5000); 
+        appStateListenerRegistration = bContext.registerService(ApplicationStateListener.class, listener, properties);
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        ServletContext context = sce.getServletContext();
+        IncidentListener listener = (IncidentListener) context.getAttribute(INCIDENT_LISTENER_ATTRIBUTE);
+        FFDC.deregisterIncidentForwarder(listener);
+        appStateListenerRegistration.unregister();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
   <modules>
     <module>liberty-managed</module>
     <module>liberty-remote</module>
+    <module>liberty-support-feature</module>
   </modules>
 
   <!-- Profiles for WLP vs OL -->


### PR DESCRIPTION
#### Short description of what this resolves:
Ensures that app startup exceptions on the server are reported back to the client correctly

#### Changes proposed in this pull request:

- Refactor the existing exception finding code to allow extension
- Create a liberty user feature which can report app startup exceptions
- Make the container use the user feature to retrieve the app startup exception information

**Fixes**: #36

#### Notes

The following features would be good additions but have not been implemented:
* Allow the remote container to also use the user feature
* Add an option to have the managed container to automatically install and enable the user feature