### PR TITLE
Resolve server.env variables at server start-up

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -52,6 +52,17 @@
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
         <version>1.2</version>
+        <configuration>
+          <skip>${skipTests}</skip>
+          <serverName>defaultServer</serverName>
+          <assemblyArtifact>
+            <groupId>${runtimeGroupId}</groupId>
+            <artifactId>${runtimeArtifactId}</artifactId>
+            <version>${runtimeVersion}</version>
+            <type>zip</type>
+          </assemblyArtifact>
+          <serverEnv>src/test/resources/server.env</serverEnv>
+        </configuration>
         <executions>
           <execution>
             <id>create-server</id>
@@ -78,16 +89,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <skip>${skipTests}</skip>
-          <serverName>defaultServer</serverName>
-          <assemblyArtifact>
-            <groupId>${runtimeGroupId}</groupId>
-            <artifactId>${runtimeArtifactId}</artifactId>
-            <version>${runtimeVersion}</version>
-            <type>zip</type>
-          </assemblyArtifact>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -299,7 +299,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
    }
 
     /***
-     * Searches and parses existant server.env files to the ProcessBuilder.environment prior to server start-up
+     * Searches and parses existing server.env files to the ProcessBuilder.environment prior to server start-up
      *
      * The server management script searches for server.env files in two locations:
      * ${wlp.install.dir}/etc/server.env and ${server.config.dir}/server.env. If both files are present, the
@@ -331,7 +331,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
             if(key.matches(alphaNumPattern) && value.matches(alphaNumPattern))
                 environment.put(key, props.getProperty(key));
             else
-                throw new LifecycleException("Non alphanumeric values in server.env not allowed! ( " + key + " = " + value + " )");
+                throw new LifecycleException("Non-alphanumeric values in server.env not allowed! ( " + key + " = " + value + " )");
         }
     }
 

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
@@ -1,0 +1,37 @@
+package io.openliberty.arquillian.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import javax.annotation.Resource;
+import org.junit.Assert;
+
+@RunWith(Arquillian.class)
+public class WLPResourceTestCase {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Resource(lookup = "env/foo")
+    String foo;
+
+    @Test
+    public void serverXMLJNDIEntryShouldNotBeNull(){
+        Assert.assertNotNull(foo);
+    }
+
+    @Test
+    public void serverEnvironmentVariablesShouldBeSet(){
+        Assert.assertNotNull(System.getenv("foo"));
+        Assert.assertNotNull(System.getenv("WLP_SKIP_MAXPERMSIZE"));
+        Assert.assertNotNull(System.getenv("keystore_password"));
+    }
+
+}

--- a/liberty-managed/src/test/resources/server-with-management.xml
+++ b/liberty-managed/src/test/resources/server-with-management.xml
@@ -7,6 +7,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-1.2</feature>
         <feature>j2eeManagement-1.1</feature>
+        <feature>jndi-1.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 
@@ -16,4 +17,5 @@
 
     <applicationMonitor updateTrigger="mbean" />
 
+    <jndiEntry jndiName="env/foo" value="${env.foo}" />
 </server>

--- a/liberty-managed/src/test/resources/server.env
+++ b/liberty-managed/src/test/resources/server.env
@@ -1,0 +1,3 @@
+keystore_password=LO4ZKcuZJZFzgpFTaDjzW21
+WLP_SKIP_MAXPERMSIZE=true
+foo=bar

--- a/liberty-managed/src/test/resources/server.xml
+++ b/liberty-managed/src/test/resources/server.xml
@@ -6,6 +6,7 @@
         <feature>jsp-2.3</feature>
         <feature>localConnector-1.0</feature>
         <feature>cdi-1.2</feature>
+        <feature>jndi-1.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 
@@ -14,5 +15,7 @@
         id="defaultHttpEndpoint" />
 
     <applicationMonitor updateTrigger="mbean" />
+
+    <jndiEntry jndiName="env/foo" value="${env.foo}" />
 
 </server>


### PR DESCRIPTION
#### Short description of what this resolves:
When running an arquillian liberty managed container test, the specifiec environment variables are not resolved in the server.xml file. WLPManagedContainer.class can be seen trying to find the server.env, however, a running app in the runtime using server.env is not resolved during testing.
See #40 

#### Changes proposed in this pull request:

- Create a pre server start-up parser for server.env, in accordance with `bin/server.bat`
- Run tests ensuring functionality by doing `@Resource`-injections and environment variable lookups.


**Fixes**: #40 
