### PR TITLE
'bin/server' shellscript execution instead of 'bin/tools/ws-server.jar'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ jdk:
     - oraclejdk8
     - openjdk9
 env:
+    - RUNTIME=ol RUNTIME_VERSION=19.0.0.1
     - RUNTIME=ol RUNTIME_VERSION=18.0.0.1
     - RUNTIME=ol RUNTIME_VERSION=17.0.0.4
+    - RUNTIME=wlp RUNTIME_VERSION=19.0.0.1
     - RUNTIME=wlp RUNTIME_VERSION=18.0.0.1
     - RUNTIME=wlp RUNTIME_VERSION=17.0.0.4
 script:

--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -37,6 +37,7 @@ Default Protocol: Servlet 3.0
 | wlpHome | String | None | Home directory of the WLP runtime. |
 | serverName | String | defaultServer | Name of the server to start. |
 | httpPort | Integer | 9080 | HTTP Port of the server.  |
+| javaVmArguments | String | None | JVM Arguments to pass into the WLP runtime.  |
 | deployType | String | dropins | Type of deployment (available: dropins or xml) |
 | sharedLib | String | None | ID of the shared library reference; if provided it will be used as the commonLibraryRef attribute of the application/classloader configuration element |
 | securityConfiguration | String | None | When using xml deployType the referred file will be embedded within the application tag into the server.xml and should be used to configure the security settings. |

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -52,6 +52,17 @@
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
         <version>1.2</version>
+        <configuration>
+          <skip>${skipTests}</skip>
+          <serverName>defaultServer</serverName>
+          <assemblyArtifact>
+            <groupId>${runtimeGroupId}</groupId>
+            <artifactId>${runtimeArtifactId}</artifactId>
+            <version>${runtimeVersion}</version>
+            <type>zip</type>
+          </assemblyArtifact>
+          <serverEnv>src/test/resources/server.env</serverEnv>
+        </configuration>
         <executions>
           <execution>
             <id>create-server</id>
@@ -78,16 +89,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <skip>${skipTests}</skip>
-          <serverName>defaultServer</serverName>
-          <assemblyArtifact>
-            <groupId>${runtimeGroupId}</groupId>
-            <artifactId>${runtimeArtifactId}</artifactId>
-            <version>${runtimeVersion}</version>
-            <type>zip</type>
-          </assemblyArtifact>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
@@ -1,0 +1,37 @@
+package io.openliberty.arquillian.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import javax.annotation.Resource;
+import org.junit.Assert;
+
+@RunWith(Arquillian.class)
+public class WLPResourceTestCase {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Resource(lookup = "env/foo")
+    String foo;
+
+    @Test
+    public void serverXMLResourceInjectionShouldHaveCorrectValue(){
+        Assert.assertEquals("bar" ,foo);
+    }
+
+    @Test
+    public void serverEnvironmentVariablesShouldBeSet(){
+        Assert.assertNotNull(System.getenv("foo"));
+        Assert.assertNotNull(System.getenv("WLP_SKIP_MAXPERMSIZE"));
+        Assert.assertNotNull(System.getenv("keystore_password"));
+    }
+
+}

--- a/liberty-managed/src/test/resources/server-with-management.xml
+++ b/liberty-managed/src/test/resources/server-with-management.xml
@@ -7,6 +7,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-1.2</feature>
         <feature>j2eeManagement-1.1</feature>
+        <feature>jndi-1.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 
@@ -16,4 +17,5 @@
 
     <applicationMonitor updateTrigger="mbean" />
 
+    <jndiEntry jndiName="env/foo" value="${env.foo}" />
 </server>

--- a/liberty-managed/src/test/resources/server.env
+++ b/liberty-managed/src/test/resources/server.env
@@ -1,0 +1,3 @@
+keystore_password=LO4ZKcuZJZFzgpFTaDjzW21
+WLP_SKIP_MAXPERMSIZE=true
+foo=bar

--- a/liberty-managed/src/test/resources/server.xml
+++ b/liberty-managed/src/test/resources/server.xml
@@ -6,6 +6,7 @@
         <feature>jsp-2.3</feature>
         <feature>localConnector-1.0</feature>
         <feature>cdi-1.2</feature>
+        <feature>jndi-1.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 
@@ -14,5 +15,7 @@
         id="defaultHttpEndpoint" />
 
     <applicationMonitor updateTrigger="mbean" />
+
+    <jndiEntry jndiName="env/foo" value="${env.foo}" />
 
 </server>


### PR DESCRIPTION
#### Short description of what this resolves:
**Summary of discussion #40:**

- `bin/server` shellscript already handles jvm.options + server.env pre-processing before server start-up, we would want `liberty-managed` to re-use this script rather than programmatically tailoring its own.
- Future liberty version `19.0.0.1?` will support passing generic JVM arguments to the `bin/server`

#### Changes proposed in this pull request:

- [x] `bin/server run <servername>` used to start server with ConsoleConsumer. 
_Comment:_ Tests passing.
- [x] Support passing of JVM flags e.g. (from code): `-Dcom.ibm.ws.logging.console.log.level=INFO`
_Comment:_ `19.0.0.2` would have allowed the passing of JVM args directly to the shell script. However, this would cause issues with older versions of liberty. The proposed solution (@aguibert ) is to use `JAVA_TOOL_OPTIONS` on `ProcessBuilder` which should work for all JDKs.
- [x] Gracefully close server using `bin/server stop`

List will be updated as work goes on..

**Fixes**: #40 
