### PR TITLE
Test on java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ jdk:
     - openjdk7
     - oraclejdk8
     - openjdk9
+    - oraclejdk11
 env:
     - RUNTIME=ol RUNTIME_VERSION=19.0.0.2
     - RUNTIME=ol RUNTIME_VERSION=18.0.0.4
     - RUNTIME=wlp RUNTIME_VERSION=19.0.0.2
     - RUNTIME=wlp RUNTIME_VERSION=18.0.0.4
+matrix:
+    exclude:
+    - jdk: oraclejdk11
+      env: RUNTIME=ol RUNTIME_VERSION=18.0.0.4
+    - jdk: oraclejdk11
+      env: RUNTIME=wlp RUNTIME_VERSION=18.0.0.4
 script:
 - travis_wait mvn verify -Druntime=$RUNTIME -DruntimeVersion=$RUNTIME_VERSION

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -43,6 +43,20 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>java-11</id>
+      <activation>
+          <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <!-- Build -->
@@ -51,7 +65,7 @@
       <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>1.2</version>
+        <version>2.6.4</version>
         <configuration>
           <skip>${skipTests}</skip>
           <serverName>defaultServer</serverName>
@@ -69,200 +83,200 @@
             <!-- Plugin execution only succeeds here in the correct order because
                  execution id of the test is not 'default-test'.
                  Because Maven. See MNG-5799 and MNG-5987 -->
-            <phase>test</phase>
-            <goals>
-              <goal>create-server</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>create-server-management</id>
+                 <phase>test</phase>
+                 <goals>
+                  <goal>create-server</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>create-server-management</id>
             <!-- Plugin execution only succeeds here in the correct order because
                  execution id of the test is not 'default-test'.
                  Because Maven. See MNG-5799 and MNG-5987 -->
-            <phase>test</phase>
+                 <phase>test</phase>
+                 <configuration>
+                  <serverName>managementServer</serverName>
+                  <configFile>src/test/resources/server-with-management.xml</configFile>
+                </configuration>
+                <goals>
+                  <goal>create-server</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.1.1</version>
+            <executions>
+              <execution>
+                <id>extract-support-feature</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+              </execution>
+            </executions>
             <configuration>
-              <serverName>managementServer</serverName>
-              <configFile>src/test/resources/server-with-management.xml</configFile>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>arquillian-liberty-support</artifactId>
+                  <version>${project.version}</version>
+                  <type>zip</type>
+                  <classifier>feature</classifier>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
+                </artifactItem>
+              </artifactItems>
             </configuration>
-            <goals>
-              <goal>create-server</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.1</version>
-        <executions>
-          <execution>
-            <id>extract-support-feature</id>
-            <phase>test</phase>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <artifactItems>
-            <artifactItem>
-              <groupId>${project.groupId}</groupId>
-              <artifactId>arquillian-liberty-support</artifactId>
-              <version>${project.version}</version>
-              <type>zip</type>
-              <classifier>feature</classifier>
-              <overWrite>false</overWrite>
-              <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
-            </artifactItem>
-          </artifactItems>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${version.surefire.plugin}</version>
-        <configuration>
-          <skip>true</skip>
-          <systemProperties>
-            <property>
-              <name>java.util.logging.config.file</name>
-              <value>${basedir}/src/test/resources/logging.properties</value>
-            </property>
-          </systemProperties>
-          <argLine>-Dproject.build.directory=${project.build.directory}</argLine>
-          <trimStackTrace>false</trimStackTrace>
-        </configuration>
-        <executions>
-          <execution>
-            <id>wlp-dropins-deployment-test</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${version.surefire.plugin}</version>
             <configuration>
-              <skip>${skipTests}</skip>
-              <reportsDirectory>${project.build.directory}/surefire-reports/wlp-dropins-deployment-test
-              </reportsDirectory>
-              <systemPropertyVariables>
-                <arquillian.launch>wlp-dropins-deployment</arquillian.launch>
-              </systemPropertyVariables>
-              <excludes>
-                <exclude>**/needsmanagementmbeans/**</exclude>
-                <exclude>**/needssupportfeature/**</exclude>
-              </excludes>
+              <skip>true</skip>
+              <systemProperties>
+                <property>
+                  <name>java.util.logging.config.file</name>
+                  <value>${basedir}/src/test/resources/logging.properties</value>
+                </property>
+              </systemProperties>
+              <argLine>-Dproject.build.directory=${project.build.directory}</argLine>
+              <trimStackTrace>false</trimStackTrace>
             </configuration>
-          </execution>
-          <execution>
-            <id>wlp-xml-deployment-test</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <skip>${skipTests}</skip>
-              <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-deployment-test</reportsDirectory>
-              <systemPropertyVariables>
-                <arquillian.launch>wlp-xml-deployment</arquillian.launch>
-              </systemPropertyVariables>
-              <excludes>
-                <exclude>**/needsmanagementmbeans/**</exclude>
-                <exclude>**/needssupportfeature/**</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>wlp-xml-management-deployment-test</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <skip>${skipTests}</skip>
-              <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-test</reportsDirectory>
-              <systemPropertyVariables>
-                <arquillian.launch>wlp-xml-management-deployment</arquillian.launch>
-              </systemPropertyVariables>
-            </configuration>
-          </execution>
-          
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+            <executions>
+              <execution>
+                <id>wlp-dropins-deployment-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-dropins-deployment-test
+                  </reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-dropins-deployment</arquillian.launch>
+                  </systemPropertyVariables>
+                  <excludes>
+                    <exclude>**/needsmanagementmbeans/**</exclude>
+                    <exclude>**/needssupportfeature/**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>wlp-xml-deployment-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-deployment-test</reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-xml-deployment</arquillian.launch>
+                  </systemPropertyVariables>
+                  <excludes>
+                    <exclude>**/needsmanagementmbeans/**</exclude>
+                    <exclude>**/needssupportfeature/**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>wlp-xml-management-deployment-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-test</reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-xml-management-deployment</arquillian.launch>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
 
-  <!-- Dependencies -->
-  <dependencies>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
 
-    <!-- org.jboss.arquillian -->
-    <dependency>
-      <groupId>org.jboss.arquillian.container</groupId>
-      <artifactId>arquillian-container-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.container</groupId>
-      <artifactId>arquillian-container-test-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.protocol</groupId>
-      <artifactId>arquillian-protocol-servlet</artifactId>
-    </dependency>
+      <!-- Dependencies -->
+      <dependencies>
 
-    <dependency>
-      <groupId>org.jboss.arquillian.testenricher</groupId>
-      <artifactId>arquillian-testenricher-cdi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.testenricher</groupId>
-      <artifactId>arquillian-testenricher-ejb</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.testenricher</groupId>
-      <artifactId>arquillian-testenricher-resource</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.testenricher</groupId>
-      <artifactId>arquillian-testenricher-initialcontext</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-      <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-      <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>fluent-hc</artifactId>
-      <version>4.5.6</version>
-    </dependency>
-    
+        <!-- org.jboss.arquillian -->
+        <dependency>
+          <groupId>org.jboss.arquillian.container</groupId>
+          <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.arquillian.container</groupId>
+          <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.arquillian.protocol</groupId>
+          <artifactId>arquillian-protocol-servlet</artifactId>
+        </dependency>
 
-    <!-- Java EE Spec APIs -->
+        <dependency>
+          <groupId>org.jboss.arquillian.testenricher</groupId>
+          <artifactId>arquillian-testenricher-cdi</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.arquillian.testenricher</groupId>
+          <artifactId>arquillian-testenricher-ejb</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.arquillian.testenricher</groupId>
+          <artifactId>arquillian-testenricher-resource</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.arquillian.testenricher</groupId>
+          <artifactId>arquillian-testenricher-initialcontext</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+          <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+          <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+          <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-      <version>[1.0,)</version>
-    </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>fluent-hc</artifactId>
+          <version>4.5.6</version>
+        </dependency>
 
-    <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
-    </dependency>
 
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <version>1.2</version>
-    </dependency>
+        <!-- Java EE Spec APIs -->
+
+        <dependency>
+          <groupId>org.jboss.spec.javax.servlet</groupId>
+          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+          <version>[1.0,)</version>
+        </dependency>
+
+        <dependency>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+          <version>1</version>
+        </dependency>
+
+        <dependency>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+          <version>1.2</version>
+        </dependency>
 
     <!-- WELD classes, these are present in FFDC
-         and are sometimes instances of TCK @ShouldThrow exceptions -->
+    and are sometimes instances of TCK @ShouldThrow exceptions -->
 
     <dependency>
       <groupId>org.jboss.weld</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <runtime>ol</runtime>
         <runtimeGroupId>io.openliberty</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>18.0.0.1</runtimeVersion>
+        <runtimeVersion>18.0.0.4</runtimeVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
#### Short description of what this resolves:
Update Travis to test on Java 11. Adds a `javax.annotation-api` test dependency for the `WLPResourceTestCase` when running on Java 11. 