### PR TITLE
Allow hostname verification to be disabled through arquillian.xml

### DIFF
--- a/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainerConfiguration.java
+++ b/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainerConfiguration.java
@@ -42,6 +42,7 @@ public class WLPRemoteContainerConfiguration implements ContainerConfiguration {
     private String hostName;
     private int httpPort = 9080;
     private int httpsPort = 9443;
+    private boolean disableHostnameVerification = false;
     private boolean outputToConsole = true;
 
     @Override
@@ -148,4 +149,11 @@ public class WLPRemoteContainerConfiguration implements ContainerConfiguration {
         this.httpsPort = httpsPort;
     }
 
+    public boolean isDisableHostnameVerification() {
+        return disableHostnameVerification;
+    }
+
+    public void setDisableHostnameVerification(boolean disableHostnameVerification) {
+        this.disableHostnameVerification = disableHostnameVerification;
+    }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Allows disabling hostname verification for the WLPRestClient used in the remote adapter.

#### Changes proposed in this pull request:
- adds 'disableHostnameVerification', boolean: true|false as a configuration option to arquillian.xml
- hostname verification is enabled by default.
- configures the SSLContext with a trust manager that trusts all certificates.
- sets the NoopHostnameVerifier on the http client.


**Fixes**: #47
