### PR TITLE
Shutdown server using server stop command

### DIFF
--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -48,6 +48,7 @@ Default Protocol: Servlet 3.0
 | verifyApps | String | None | Specifies a comma-separated list of names of applications that will be verified to be started before tests are executed |
 | verifyAppDeployTimeout | Integer | 20 | Time in seconds to wait for the verifyApps application deployment to complete and the applications to start |
 | serverStartTimeout | Integer | 30 | Time in seconds to wait for the application server to start |
+| serverStopTimeout | Integer | 30 | Time in seconds to wait for the application server to stop |
 | appDeployTimeout | Integer | 20 | Time in seconds to wait for the application deployment to complete and the application to start |
 | appUndeployTimeout | Integer | 2 | Time in seconds to wait for the application undeployment to complete |
 | allowConnectingToRunningServer | Boolean | false | Allow a connection to be made to an already running application server process |

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/Interruptor.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/Interruptor.java
@@ -1,0 +1,82 @@
+package io.openliberty.arquillian.managed;
+
+/**
+ * Interrupts a target thread after a specified length of time
+ * <p>
+ * Used to apply a timeout around waiting for process to end
+ * <p>
+ * Example usage:
+ * <p><pre><code>
+ * Interruptor interruptor = new Interruptor(Thread.currentThread(500));
+ * try {
+ *    interruptor.start();
+ *    Thread.sleep(1000);
+ *    interruptor.stop();
+ * } catch (InterruptedException e) {
+ *    // Was interrupted!
+ * }
+ * </code></pre>
+ */
+public class Interruptor {
+   
+   private final Thread interruptTarget;
+   private final long timeToWait;
+   private Thread taskThread;
+   private boolean running = false;
+   
+   /**
+    * Create an interruptor to interrupt the given target thread after the specified time
+    * 
+    * @param interruptTarget the thread this interruptor will interrupt
+    * @param timeToWait the time it should wait before interrupting it
+    */
+   public Interruptor(Thread interruptTarget, long timeToWait) {
+      this.interruptTarget = interruptTarget;
+      this.timeToWait = timeToWait;
+   }
+
+   /**
+    * Starts the countdown to the interruption of the target thread
+    */
+   public synchronized void start() {
+      if (running) {
+         throw new IllegalArgumentException("Interruptor has already been started");
+      }
+      taskThread = new Thread() {
+         @Override
+         public void run() {
+            try {
+               sleep(timeToWait);
+               doInterrupt();
+            } catch (InterruptedException e) {
+               // stop() has been called
+               // nothing to do, just return
+            }
+         }
+      };
+      running = true;
+      taskThread.start();
+   }
+
+   /**
+    * Stop the interruptor, cancelling the scheduled interruption
+    * <p>
+    * If an interruption has already occurred, this method will clear the thread interrupt flag
+    * <p>
+    * If an interruption has not occurred yet, this method will cancel the pending interruption 
+    */
+   public synchronized void stop() {
+      running = false;
+      taskThread.interrupt();
+   }
+   
+   // Do the actual interruption
+   // Synchronized to ensure that interruption will not occur after stop is called
+   private synchronized void doInterrupt() {
+      if (running) {
+         interruptTarget.interrupt();
+         running = false;
+      }
+   }
+
+}

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.ProcessBuilder.Redirect;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -38,6 +39,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,6 +51,7 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
+import javax.swing.text.html.MinimalHTMLWriter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -222,7 +226,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
 
             wlpProcess = pb.start();
 
-            new Thread(new ConsoleConsumer()).start();
+            new Thread(new ConsoleConsumer(wlpProcess)).start();
 
              cmd = getServerCommand(CommandType.STOP);
              shutdownThread = getShutDownThread(cmd);
@@ -1141,18 +1145,60 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
          Runtime.getRuntime().removeShutdownHook(shutdownThread);
          shutdownThread = null;
       }
-      try {
-         if (wlpProcess != null) {
-            wlpProcess.destroy();
-            wlpProcess.waitFor();
-            wlpProcess = null;
+      
+      // Only attempt to stop the server if we started it
+      if (wlpProcess != null) {
+         // First run "server stop"
+         ProcessBuilder stopProcessBuilder = new ProcessBuilder(getServerCommand(CommandType.STOP));
+         stopProcessBuilder.redirectErrorStream(true);
+         try {
+            Process stopProcess = stopProcessBuilder.start();
+            new Thread(new ConsoleConsumer(stopProcess)).start();
+            int rc = waitFor(stopProcess, containerConfiguration.getServerStopTimeout(), TimeUnit.SECONDS);
+            if (rc != 0) {
+               throw new LifecycleException("Server stop failed, see log for details. RC = " + rc);
+            }
+         } catch (TimeoutException e) {
+            throw new LifecycleException("Server stop command did not complete within the server stop timeout", e);
+         } catch (Exception e) {
+            throw new LifecycleException("Failed to run server stop command");
          }
-      } catch (Exception e) {
-         throw new LifecycleException("Could not stop container", e);
+         
+         try {
+            // Server stop succeeded so launched process should now end
+            waitFor(wlpProcess, containerConfiguration.getServerStopTimeout(), TimeUnit.SECONDS);
+            wlpProcess = null;
+         } catch (Exception e) {
+            throw new LifecycleException("Server stop command ran but the server process did not exit", e);
+         }
       }
-
+      
       if (log.isLoggable(Level.FINER)) {
          log.exiting(className, "stop");
+      }
+   }
+   
+   /**
+    * Waits for the given process to finish and returns its return code
+    * <p>
+    * If the process does not finish within the specified time limit, a TimeoutException is thrown instead
+    * 
+    * @param process the process to wait for
+    * @param time the time to wait
+    * @param timeUnit the unit for {@code time}
+    * @return the process return code
+    * @throws TimeoutException if the process does not finish within the specified time
+    */
+   public int waitFor(Process process, int time, TimeUnit timeUnit) throws TimeoutException {
+      long millisToWait = TimeUnit.MILLISECONDS.convert(time, timeUnit);
+      Interruptor interruptor = new Interruptor(Thread.currentThread(), millisToWait);
+      try {
+         interruptor.start();
+         int rc = process.waitFor();
+         interruptor.stop();
+         return rc;
+      } catch (InterruptedException e) {
+         throw new TimeoutException("Timed out waiting for process to stop after " + time + " " + timeUnit);
       }
    }
 
@@ -1595,10 +1641,17 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
     * @author Stuart Douglas
     */
    private class ConsoleConsumer implements Runnable {
+      
+       private final Process process;
+       
+       public ConsoleConsumer(Process process) {
+          super();
+          this.process = process;
+       }
 
-       @Override
+      @Override
        public void run() {
-           final InputStream stream = wlpProcess.getInputStream();
+           final InputStream stream = process.getInputStream();
            final boolean writeOutput = containerConfiguration.isOutputToConsole();
 
            try {

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -27,6 +27,7 @@ public class WLPManagedContainerConfiguration implements
    private int httpPort = 0;
    
    private int serverStartTimeout = 30;
+   private int serverStopTimeout = 30;
    private int appDeployTimeout = 20;
    private int appUndeployTimeout = 2;
    private String sharedLib = null;
@@ -172,6 +173,14 @@ public class WLPManagedContainerConfiguration implements
 
    public void setServerStartTimeout(int serverStartTimeout) {
       this.serverStartTimeout = serverStartTimeout;
+   }
+
+   public int getServerStopTimeout() {
+      return serverStopTimeout;
+   }
+
+   public void setServerStopTimeout(int serverStopTimeout) {
+      this.serverStopTimeout = serverStopTimeout;
    }
 
    public int getAppDeployTimeout() {


### PR DESCRIPTION
#### Short description of what this resolves:

Killing the "server run" process directly does not work on Windows so use `server stop` instead.

#### Changes proposed in this pull request:

- Use `server stop` in the `stop()` method
- Added a timeout for waiting for the server to stop
  - Timeout is implemented using a new class which interrupts after a requested time since Java 7 has no `Process.waitFor()` method which accepts a timeout parameter.

**Fixes**: #49 
