### PR TITLE
Fix remote container tests for 19.0.0.3

### DIFF
--- a/liberty-remote/src/test/resources/server.xml
+++ b/liberty-remote/src/test/resources/server.xml
@@ -22,7 +22,7 @@
 	<quickStartSecurity userName="admin" userPassword="admin" />
 
 	<!-- Enable the keystore -->
-	<keyStore id="defaultKeyStore" password="password" />
+	<keyStore id="defaultKeyStore" password="password" location="key.jks" type="JKS"/>
 
 	<applicationMonitor updateTrigger="mbean" />
 	<logging consoleLogLevel="INFO" />


### PR DESCRIPTION
The test is currently set up to expect the server to generate a key.jks
file. Since 19.0.0.3, liberty defaults to generating a key.p12 file
instead.

As a quick fix, change the server config to specify a key.jks file as
the test expects.

We can't change the server config to always create key.p12 as earlier
versions of liberty can't generate this file format.

<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-


**Fixes**: #
