### PR TITLE
Correct getter method

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -261,7 +261,7 @@ public class WLPManagedContainerConfiguration implements
    }
 
    public int getStandardFileDeleteRetryInterval() {
-      return fileDeleteRetries;
+      return standardFileDeleteRetryInterval;
    }
 
    public void setStandardFileDeleteRetryInterval(int standardFileDeleteRetryInterval) {


### PR DESCRIPTION
Signed-off-by: Benjamin Confino <benjamic@uk.ibm.com>

A getter method in WLPManagedContainerConfiguration incorrectly returns the wrong variable. 

This pull request simply changes the return statement to return the correct field. 