### PR TITLE
Set log level to info for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,6 @@ install:
   - cmd: java -version
 
 build_script:
-      - "mvn verify -Druntime=%RUNTIME% -DruntimeVersion=19.0.0.3"
+      - "mvn verify -Druntime=%RUNTIME% -DruntimeVersion=19.0.0.3 -Plog-info"
 
 test: off

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -19,9 +19,16 @@
 
   <properties>
     <skipTests>false</skipTests>
+    <loggingPropertiesFile>${basedir}/src/test/resources/logging.properties</loggingPropertiesFile>
   </properties>
 
   <profiles>
+    <profile>
+      <id>log-info</id>
+      <properties>
+        <loggingPropertiesFile>${basedir}/src/test/resources/logging-info.properties</loggingPropertiesFile>
+      </properties>
+    </profile>
     <profile>
       <id>jigsaw</id>
       <activation>
@@ -140,7 +147,7 @@
               <systemProperties>
                 <property>
                   <name>java.util.logging.config.file</name>
-                  <value>${basedir}/src/test/resources/logging.properties</value>
+                  <value>${loggingPropertiesFile}</value>
                 </property>
               </systemProperties>
               <argLine>-Dproject.build.directory=${project.build.directory}</argLine>

--- a/liberty-managed/src/test/resources/logging-info.properties
+++ b/liberty-managed/src/test/resources/logging-info.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2019, IBM, and individual contributors
+# identified by the Git commit log. 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+# Log everything to INFO
+.level= INFO

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -16,6 +16,7 @@
     <skipTests>false</skipTests>
     <version.jackson>2.9.8</version.jackson>
     <version.apache.fluent.hc>4.5.6</version.apache.fluent.hc>
+    <loggingPropertiesFile>${basedir}/src/test/resources/logging.properties</loggingPropertiesFile>
   </properties>
   
   <profiles>
@@ -40,6 +41,12 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>log-info</id>
+      <properties>
+        <loggingPropertiesFile>${basedir}/src/test/resources/logging-info.properties</loggingPropertiesFile>
+      </properties>
+    </profile>
   </profiles>
 
   <build>
@@ -53,7 +60,7 @@
           <systemProperties>
             <property>
               <name>java.util.logging.config.file</name>
-              <value>${basedir}/src/test/resources/logging.properties</value>
+              <value>${loggingPropertiesFile}</value>
             </property>
             <property>
               <name>javax.net.ssl.trustStore</name>

--- a/liberty-remote/src/test/resources/logging-info.properties
+++ b/liberty-remote/src/test/resources/logging-info.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2019, IBM, and individual contributors
+# identified by the Git commit log. 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+# Log everything to INFO
+.level= INFO


### PR DESCRIPTION
Currently the AppVeyor logs are being truncated due to the logging level being too fine grained. This PR retains the existing logging level for Travis, which doesn't have an issue with the log size, and sets the logging level just to `INFO` for AppVeyor. 