### PR TITLE
update to support Jakarta EE 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ jdk:
     - openjdk9
     - oraclejdk11
 env:
-    - RUNTIME=ol RUNTIME_VERSION=19.0.0.3
-    - RUNTIME=ol RUNTIME_VERSION=18.0.0.4
+    - RUNTIME=ol RUNTIME_VERSION=20.0.0.11-beta
     - RUNTIME=wlp RUNTIME_VERSION=19.0.0.3
     - RUNTIME=wlp RUNTIME_VERSION=18.0.0.4
 matrix:
     exclude:
-    - jdk: oraclejdk11
-      env: RUNTIME=ol RUNTIME_VERSION=18.0.0.4
     - jdk: oraclejdk11
       env: RUNTIME=wlp RUNTIME_VERSION=18.0.0.4
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,6 @@ install:
   - cmd: java -version
 
 build_script:
-      - "mvn verify -Druntime=%RUNTIME% -DruntimeVersion=19.0.0.3 -Plog-info"
+      - "mvn verify -Druntime=%RUNTIME% -DruntimeVersion=20.0.0.11-beta -Plog-info"
 
 test: off

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -57,9 +57,9 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <version>2.0.0-RC1</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -227,18 +227,17 @@
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet</artifactId>
         </dependency>
-
         <dependency>
           <groupId>org.jboss.arquillian.testenricher</groupId>
-          <artifactId>arquillian-testenricher-cdi</artifactId>
+          <artifactId>arquillian-testenricher-cdi-jakarta</artifactId>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.testenricher</groupId>
-          <artifactId>arquillian-testenricher-ejb</artifactId>
+          <artifactId>arquillian-testenricher-ejb-jakarta</artifactId>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.testenricher</groupId>
-          <artifactId>arquillian-testenricher-resource</artifactId>
+          <artifactId>arquillian-testenricher-resource-jakarta</artifactId>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.testenricher</groupId>
@@ -262,33 +261,34 @@
         </dependency>
 
 
-        <!-- Java EE Spec APIs -->
-
+        <!-- Jakarta EE Spec APIs -->
         <dependency>
-          <groupId>org.jboss.spec.javax.servlet</groupId>
-          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-          <version>[1.0,)</version>
+          <groupId>jakarta.servlet</groupId>
+          <artifactId>jakarta.servlet-api</artifactId>
+          <version>[5.0,)</version>
         </dependency>
 
         <dependency>
-          <groupId>javax.inject</groupId>
-          <artifactId>javax.inject</artifactId>
-          <version>1</version>
+          <groupId>jakarta.inject</groupId>
+          <artifactId>jakarta.inject-api</artifactId>
+          <version>[2.0,)</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/jakarta.enterprise/jakarta.enterprise.cdi-api -->
         <dependency>
-          <groupId>javax.enterprise</groupId>
-          <artifactId>cdi-api</artifactId>
-          <version>1.2</version>
+          <groupId>jakarta.enterprise</groupId>
+          <artifactId>jakarta.enterprise.cdi-api</artifactId>
+          <version>3.0.0-M4</version>
         </dependency>
+
+        
 
     <!-- WELD classes, these are present in FFDC
     and are sometimes instances of TCK @ShouldThrow exceptions -->
-
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-bom</artifactId>
-      <version>3.0.4.Final</version>
+      <version>4.0.0.Alpha3</version>
       <type>pom</type>
     </dependency>
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -70,9 +70,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+        <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>2.6.4</version>
+        <version>3.2.3</version>
         <configuration>
           <skip>${skipTests}</skip>
           <serverName>defaultServer</serverName>
@@ -91,22 +91,26 @@
                  execution id of the test is not 'default-test'.
                  Because Maven. See MNG-5799 and MNG-5987 -->
                  <phase>test</phase>
+                 <configuration>
+                  <serverName>defaultServer</serverName>
+                   <serverXmlFile>src/test/resources/server.xml</serverXmlFile>
+                 </configuration>
                  <goals>
-                  <goal>create-server</goal>
+                  <goal>create</goal>
                 </goals>
-              </execution>
-              <execution>
-                <id>create-server-management</id>
+          </execution>
+          <execution>
+            <id>create-server-management</id>
             <!-- Plugin execution only succeeds here in the correct order because
                  execution id of the test is not 'default-test'.
                  Because Maven. See MNG-5799 and MNG-5987 -->
                  <phase>test</phase>
                  <configuration>
                   <serverName>managementServer</serverName>
-                  <configFile>src/test/resources/server-with-management.xml</configFile>
+                  <serverXmlFile>src/test/resources/server-with-management.xml</serverXmlFile>
                 </configuration>
                 <goals>
-                  <goal>create-server</goal>
+                  <goal>create</goal>
                 </goals>
               </execution>
             </executions>

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -225,7 +225,7 @@
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
-          <artifactId>arquillian-protocol-servlet</artifactId>
+          <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.testenricher</groupId>

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1221,7 +1221,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
          log.entering(className, "getDefaultProtocol");
       }
 
-      String defaultProtocol = "Servlet 3.0";
+      String defaultProtocol = "Servlet 5.0";
 
       if (log.isLoggable(Level.FINER)) {
          log.exiting(className, "getDefaultProtocol", defaultProtocol);

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -118,7 +118,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
    private static final String WLP_USER_DIR = "WLP_USER_DIR";
    private static final String JAVA_TOOL_OPTIONS = "JAVA_TOOL_OPTIONS";
    
-   private static final String ARQUILLIAN_SERVLET_NAME = "ArquillianServletRunner";
+   private static final String ARQUILLIAN_SERVLET_NAME = "ArquillianServletRunnerEE9";
 
    private static final String className = WLPManagedContainer.class.getName();
 

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/CDILogExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/CDILogExceptionLocator.java
@@ -16,8 +16,8 @@ package io.openliberty.arquillian.managed.exceptions;
 
 import java.util.logging.Logger;
 
-import javax.enterprise.inject.spi.DefinitionException;
-import javax.enterprise.inject.spi.DeploymentException;
+import jakarta.enterprise.inject.spi.DefinitionException;
+import jakarta.enterprise.inject.spi.DeploymentException;
 
 /**
  * This is old code to determine CDI exceptions from log lines
@@ -36,7 +36,7 @@ public class CDILogExceptionLocator implements DeploymentExceptionLocator {
                  logLine.contains("UnserializableDependencyException")) {
             /*
              * The CDI specification allows an implementation to throw a subclass of
-             * javax.enterprise.inject.spi.DeploymentException. Weld has three types
+             * jakarta.enterprise.inject.spi.DeploymentException. Weld has three types
              * such exceptions:
              *  - org.jboss.weld.exceptions.DeploymentException
              *  - org.jboss.weld.exceptions.InconsistentSpecializationException

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/NestedExceptionBuilder.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/NestedExceptionBuilder.java
@@ -38,10 +38,10 @@ public class NestedExceptionBuilder {
      */
     private final static Map<String, String> exceptionMappings = new HashMap<>();
     static {
-        exceptionMappings.put("org.jboss.weld.exceptions.DeploymentException", "javax.enterprise.inject.spi.DeploymentException");
-        exceptionMappings.put("org.jboss.weld.exceptions.InconsistentSpecializationException", "javax.enterprise.inject.spi.DeploymentException");
-        exceptionMappings.put("org.jboss.weld.exceptions.UnserializableDependencyException", "javax.enterprise.inject.spi.DeploymentException");
-        exceptionMappings.put("org.jboss.weld.exceptions.DefinitionException", "javax.enterprise.inject.spi.DefinitionException");
+        exceptionMappings.put("org.jboss.weld.exceptions.DeploymentException", "jakarta.enterprise.inject.spi.DeploymentException");
+        exceptionMappings.put("org.jboss.weld.exceptions.InconsistentSpecializationException", "jakarta.enterprise.inject.spi.DeploymentException");
+        exceptionMappings.put("org.jboss.weld.exceptions.UnserializableDependencyException", "jakarta.enterprise.inject.spi.DeploymentException");
+        exceptionMappings.put("org.jboss.weld.exceptions.DefinitionException", "jakarta.enterprise.inject.spi.DefinitionException");
     }
     
     /**

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/HelloServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/HelloServlet.java
@@ -16,11 +16,11 @@ package io.openliberty.arquillian.managed;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/HelloServlet")
 public class HelloServlet extends HttpServlet {

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/InvalidBean.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/InvalidBean.java
@@ -1,6 +1,6 @@
 package io.openliberty.arquillian.managed;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * This bean should result in a definition error because it has a public non-static field and is not Dependent scoped

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNamePart2.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPDuplicateAppNamePart2.java
@@ -1,6 +1,6 @@
 package io.openliberty.arquillian.managed;
 
-import javax.enterprise.inject.spi.DefinitionException;
+import jakarta.enterprise.inject.spi.DefinitionException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPInjectionTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPInjectionTestCase.java
@@ -14,7 +14,7 @@
  */
 package io.openliberty.arquillian.managed;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPIntegrationClientTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPIntegrationClientTestCase.java
@@ -1,21 +1,22 @@
-/*
- * Copyright 2010-2012, Red Hat Middleware LLC, and individual contributors
- * identified by the Git commit log. 
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// /*
+//  * Copyright 2010-2012, Red Hat Middleware LLC, and individual contributors
+//  * identified by the Git commit log. 
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  * http://www.apache.org/licenses/LICENSE-2.0
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
 package io.openliberty.arquillian.managed;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -30,8 +31,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-// This is based on the JettyEmbeddedClientTestCase.java
-// written by Dan Allen and Aslak Knutsen.
+// // This is based on the JettyEmbeddedClientTestCase.java
+// // written by Dan Allen and Aslak Knutsen.
 
 @RunWith(Arquillian.class)
 public class WLPIntegrationClientTestCase
@@ -40,7 +41,7 @@ public class WLPIntegrationClientTestCase
    public static EnterpriseArchive createDeployment() 
    {
       return ShrinkWrap.create(EnterpriseArchive.class, "test.ear")
-            .addAsModule(ShrinkWrap.create(WebArchive.class, "test.war")
+            .addAsModule(ShrinkWrap.create(WebArchive.class, "test1.war")
                               .addClass(HelloServlet.class))
             .addAsModule(ShrinkWrap.create(JavaArchive.class, "test.jar")
                               .addClass(WLPIntegrationClientTestCase.class)
@@ -50,30 +51,37 @@ public class WLPIntegrationClientTestCase
    @Test
    public void shouldBeAbleToInvokeServletInDeployedWebApp(@ArquillianResource URL url) throws Exception
    {
+      URL helloEndpoint = new URL(url, HelloServlet.URL_PATTERN);
+
+      HttpURLConnection conn = (HttpURLConnection) helloEndpoint.openConnection();
+      Assert.assertEquals(
+         "The url: " + helloEndpoint + " response code should be 200 but was: " + conn.getResponseCode(),
+         HttpURLConnection.HTTP_OK,
+         conn.getResponseCode());
+
       String body = readAllAndClose(
-            new URL(url, HelloServlet.URL_PATTERN).openStream());
-      
+        helloEndpoint.openStream());
       Assert.assertEquals(
             "Verify that the servlet was deployed and returns expected result",
             HelloServlet.MESSAGE,
             body);
    }
    
-   private String readAllAndClose(InputStream is) throws Exception 
+   private String readAllAndClose(InputStream is) throws Exception
    {
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      try
-      {
-         int read;
-         while( (read = is.read()) != -1)
-         {
-            out.write(read);
-         }
-      }
-      finally 
-      {
-         try { is.close(); } catch (Exception e) { }
-      }
-      return out.toString();
+       ByteArrayOutputStream out = new ByteArrayOutputStream();
+       try {
+           int read;
+           while ((read = is.read()) != -1) {
+               out.write(read);
+           }
+       } finally {
+           try {
+               is.close();
+           } catch (Exception e) {
+           }
+       }
+       return out.toString();
    }
+
 }

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
@@ -7,7 +7,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import javax.annotation.Resource;
+import jakarta.annotation.Resource;
 import org.junit.Assert;
 
 @RunWith(Arquillian.class)

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BarServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BarServlet.java
@@ -16,11 +16,11 @@ package io.openliberty.arquillian.managed.needsmanagementmbeans;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/bar")
 public class BarServlet extends HttpServlet {

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BazServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BazServlet.java
@@ -16,11 +16,11 @@ package io.openliberty.arquillian.managed.needsmanagementmbeans;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/baz")
 public class BazServlet extends HttpServlet {

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BuzServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/BuzServlet.java
@@ -16,11 +16,11 @@ package io.openliberty.arquillian.managed.needsmanagementmbeans;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/buz")
 public class BuzServlet extends HttpServlet {

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/FooServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/FooServlet.java
@@ -16,11 +16,11 @@ package io.openliberty.arquillian.managed.needsmanagementmbeans;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/foo")
 public class FooServlet extends HttpServlet {

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/OtherFooServlet.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needsmanagementmbeans/OtherFooServlet.java
@@ -16,11 +16,11 @@ package io.openliberty.arquillian.managed.needsmanagementmbeans;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/otherFoo")
 public class OtherFooServlet extends HttpServlet {

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/StartupFailureExtension.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/StartupFailureExtension.java
@@ -14,9 +14,9 @@
  */
 package io.openliberty.arquillian.managed.needssupportfeature.deploymentfailure;
 
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.Extension;
-import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
 
 /**
  * Causes a definition error by throwing a TestAppException during startup

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/WLPDeploymentExceptionTest.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/WLPDeploymentExceptionTest.java
@@ -16,7 +16,7 @@ package io.openliberty.arquillian.managed.needssupportfeature.deploymentfailure;
 
 import static org.junit.Assert.fail;
 
-import javax.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.Extension;
 
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/liberty-managed/src/test/resources/server-with-management.xml
+++ b/liberty-managed/src/test/resources/server-with-management.xml
@@ -3,9 +3,9 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.3</feature>
+        <feature>jsp-3.0</feature>
         <feature>localConnector-1.0</feature>
-        <feature>cdi-1.2</feature>
+        <feature>cdi-3.0</feature>
         <feature>j2eeManagement-1.1</feature>
         <feature>jndi-1.0</feature>
         <feature>usr:arquillian-support-1.0</feature>

--- a/liberty-managed/src/test/resources/server.xml
+++ b/liberty-managed/src/test/resources/server.xml
@@ -3,9 +3,9 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>jsp-2.3</feature>
+        <feature>jsp-3.0</feature>
         <feature>localConnector-1.0</feature>
-        <feature>cdi-1.2</feature>
+        <feature>cdi-3.0</feature>
         <feature>jndi-1.0</feature>
     </featureManager>
 

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -86,24 +86,24 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+        <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>1.2</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
-            <id>start-server</id>
+            <id>start</id>
             <!-- Plugin execution needs to be bound to previous phase.
                  Because Maven. See MNG-5799 and MNG-5987 -->
             <phase>process-test-classes</phase>
             <goals>
-              <goal>start-server</goal>
+              <goal>start</goal>
             </goals>
           </execution>
           <execution>
-            <id>stop-server</id>
+            <id>stop</id>
             <phase>test</phase>
             <goals>
-              <goal>stop-server</goal>
+              <goal>stop</goal>
             </goals>
           </execution>
         </executions>

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -168,18 +168,18 @@
       <artifactId>arquillian-testenricher-initialcontext</artifactId>
     </dependency>
 
-    <!-- Java EE Spec APIs -->
+    <!-- Jakarta EE Spec APIs -->
 
     <dependency>
-      <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-      <version>[1.0,)</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>[5.0,)</version>
     </dependency>
 
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>[2.0,)</version>
     </dependency>
 
     <!-- Testing -->

--- a/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainer.java
+++ b/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainer.java
@@ -106,7 +106,7 @@ public class WLPRemoteContainer implements DeployableContainer<WLPRemoteContaine
             log.entering(className, "getDefaultProtocol");
         }
 
-        String defaultProtocol = "Servlet 3.0";
+        String defaultProtocol = "Servlet 5.0";
 
         if (log.isLoggable(Level.FINER)) {
             log.exiting(className, "getDefaultProtocol", defaultProtocol);

--- a/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainer.java
+++ b/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainer.java
@@ -147,7 +147,7 @@ public class WLPRemoteContainer implements DeployableContainer<WLPRemoteContaine
         // Return metadata on how to contact the deployed application
         ProtocolMetaData metaData = new ProtocolMetaData();
         HTTPContext httpContext = new HTTPContext(containerConfiguration.getHostName(), containerConfiguration.getHttpPort());
-        httpContext.add(new Servlet("ArquillianServletRunner", deployName));
+        httpContext.add(new Servlet("ArquillianServletRunnerEE9", deployName));
         metaData.addContext(httpContext);
 
         if (log.isLoggable(Level.FINER)) {

--- a/liberty-remote/src/test/java/io/openliberty/arquillian/remote/HelloServlet.java
+++ b/liberty-remote/src/test/java/io/openliberty/arquillian/remote/HelloServlet.java
@@ -16,11 +16,11 @@ package io.openliberty.arquillian.remote;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/HelloServlet")
 public class HelloServlet extends HttpServlet {

--- a/liberty-remote/src/test/java/io/openliberty/arquillian/remote/WLPInjectionTestCase.java
+++ b/liberty-remote/src/test/java/io/openliberty/arquillian/remote/WLPInjectionTestCase.java
@@ -14,7 +14,7 @@
  */
 package io.openliberty.arquillian.remote;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;

--- a/liberty-support-feature/bnd.bnd
+++ b/liberty-support-feature/bnd.bnd
@@ -1,5 +1,5 @@
 Web-ContextPath: arquillian-support
-Import-Package: javax.servlet.*; version="[2.6, 3)", \
+Import-Package: jakarta.servlet.*; version="[5.0,)", \
   com.ibm.ws.container.service.app.deploy; version="[1.0, 3)", \
   *
 Bundle-Version: ${parsedVersion.osgiVersion}

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -116,9 +116,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>[5.0,)</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
+++ b/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
@@ -2,7 +2,7 @@ IBM-Feature-Version: 2
 IBM-ShortName: arquillian-support-1.0
 Subsystem-Content: arquillian-liberty-support; version=${parsedVersion.osgiVersion},
  com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-3.0; ibm.tolerates:="3.1,4.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="5.0"; type="osgi.subsystem.feature"
 Subsystem-Description: Liberty Feature to support integration for the Arquillian Project
 Subsystem-ManifestVersion: 1
 Subsystem-Name: Arquillian Support Feature

--- a/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/DeploymentExceptionServlet.java
+++ b/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/DeploymentExceptionServlet.java
@@ -20,12 +20,12 @@ import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import io.openliberty.arquillian.support.IncidentListener.ExceptionInfo;
 

--- a/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/Initializer.java
+++ b/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/Initializer.java
@@ -17,10 +17,10 @@ package io.openliberty.arquillian.support;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.annotation.WebListener;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.4.0.Final</version.arquillian_core>
+    <version.arquillian_core>1.7.0.Alpha3</version.arquillian_core>
     <version.surefire.plugin>2.21.0</version.surefire.plugin>
 
     <!-- override from parent -->
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -117,9 +117,9 @@
       </activation>
       <properties>
         <runtime>ol</runtime>
-        <runtimeGroupId>io.openliberty</runtimeGroupId>
+        <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>18.0.0.4</runtimeVersion>
+        <runtimeVersion>20.0.0.11-beta</runtimeVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>

#### Short description of what this resolves:
Add support to Liberty Arquillian for Jakarta EE 9

#### Changes proposed in this pull request:
- update dependencies in the `pom.xml` files (updating the jakarta ee specs and the `arquillian-testenricher` projects)
- relevant `javax` -> `jakarta` namespace changes
- update `ArquillianServletRunner` to `ArquillianServletRunnerEE9`