### PR TITLE
updated docs for jakarta ee 9

### DIFF
--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -15,9 +15,8 @@ The following features are required in the `server.xml` of the Liberty server.
 ```
 <!-- Enable features -->
 <featureManager>
-    <feature>jsp-2.2</feature>
+    <feature>jsp-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>j2eeManagement-1.1</feature> <!-- Optional, needed to allow injection on ArquillianResources related to servlets -->
     <feature>usr:arquillian-support-1.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
 </featureManager>
 ```
@@ -30,7 +29,7 @@ You will also need to enable the `applicationMonitor` MBean support:
 
 ## Configuration
 
-Default Protocol: Servlet 3.0
+Default Protocol: Servlet 5.0
 
 **Container Configuration Options**
 

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -551,10 +551,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
          // register servlets
          boolean addedSomeServlets = false;
          for (WebModule module : modules) {
-
-            // TODO: scan for the all the servlets in the modules (webarchive)
             List<String> servlets = getServletNames(module);
-            // List<String> servlets = getServletNames(deployName, module);
             for (String servlet : servlets) {
                   httpContext.add(new Servlet(servlet, module.contextRoot));
                addedSomeServlets = true;
@@ -753,39 +750,6 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
       }
 
       return servletNames;
-   }
-
-   /**
-    * Returns the short names of all servlets deployed in the module
-    * <p>
-    * Attempts to use J2EE management MBeans, falls back to just returning ArquillianServletRunner for testable archives and nothing otherwise.
-    */
-   private List<String> getServletNames(String appDeployName, WebModule webModule) throws DeploymentException {
-       try {
-           // If Java EE Management MBeans are present, query them for deployed servlets. This requires j2eeManagement-1.1 feature
-           Set<ObjectInstance> servletMbeans = mbsc.queryMBeans(new ObjectName("WebSphere:*,J2EEApplication=" + appDeployName + ",j2eeType=Servlet,WebModule="+webModule.name), null);
-           List<String> servletNames = new ArrayList<String>();
-           
-           for (ObjectInstance servletMbean : servletMbeans) {
-               String name = servletMbean.getObjectName().getKeyProperty("name");
-               
-               // Websphere uses the fully qualified servlet class as the servlet name, but arquillian just wants the simple name
-               if (name.contains(".")) {
-                   name = name.substring(name.lastIndexOf(".") + 1);
-               }
-               
-               servletNames.add(name);
-           }
-           
-           // J2EE Management MBeans aren't always available, so if we didn't find any servlets and this is a testable archive
-           // it ought to contain the arquillian test servlet, which is all that most tests need to work
-           if (servletNames.isEmpty() && Testable.isArchiveToTest(webModule.archive)) {
-               servletNames.add(ARQUILLIAN_SERVLET_NAME);
-           }
-           return servletNames;
-       } catch (Exception e) {
-           throw new DeploymentException("Error trying to retrieve servlet names", e);
-       }
    }
 
    private String getContextRoot(EnterpriseArchive ear, WebArchive war) throws DeploymentException {

--- a/liberty-remote/README.md
+++ b/liberty-remote/README.md
@@ -15,8 +15,8 @@ The following features are required in the `server.xml` of the Liberty server.
 ```
 <!-- Enable features -->
 <featureManager>
-    <feature>jsp-2.2</feature>
-    <feature>restConnector-1.0</feature>
+    <feature>jsp-3.0</feature>
+    <feature>restConnector-2.0</feature>
 </featureManager>
 ```
 
@@ -42,7 +42,7 @@ If you need a sample `server.xml`, please refer to the [one in our source reposi
 
 ## Configuration
 
-Default Protocol: Servlet 3.0
+Default Protocol: Servlet 5.0
 
 **Container Configuration Options**
 


### PR DESCRIPTION
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>

Updated references in the docs to use Jakarta EE 9 features and removed unused method in `WLPManagedContainer`.

References to versions of the Liberty Arquillian Plugin (ie. `usr:arquillian-support-1.0`) to be updated at a later date.
