### PR TITLE
Updated documentation for Java EE 8 and Jakarta EE 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arquillian Liberty Server Containers [![Maven Central Latest](https://maven-badges.herokuapp.com/maven-central/io.openliberty.arquillian/arquillian-parent-liberty/badge.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.openliberty.arquillian%22%20AND%20a%3A%22arquillian-parent-liberty%22) [![Build Status](https://travis-ci.org/OpenLiberty/liberty-arquillian.svg?branch=master)](https://travis-ci.org/OpenLiberty/liberty-arquillian)
 
-[Arquillian](http://arquillian.org/) is a testing framework to develop automated functional, integration and acceptance tests for your Java applications. There are two types of Liberty `DeployableContainer` implementations; [Liberty Managed](#Arquillian-Liberty-Managed-Container) and [Liberty Remote](#Arquillian-Liberty-Remote-Container).
+[Arquillian](http://arquillian.org/) is a testing framework to develop automated functional, integration and acceptance tests for your Java applications. Arquillian container adapters allow Arquillian to bind to and manage the lifecycle of a runtime. There are two types of Arquillian container adapters for Liberty: [Liberty Managed](#Arquillian-Liberty-Managed-Container) and [Liberty Remote](#Arquillian-Liberty-Remote-Container).
 
 ### Arquillian Liberty Mangaged Container
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # Arquillian Liberty Server Containers [![Maven Central Latest](https://maven-badges.herokuapp.com/maven-central/io.openliberty.arquillian/arquillian-parent-liberty/badge.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.openliberty.arquillian%22%20AND%20a%3A%22arquillian-parent-liberty%22) [![Build Status](https://travis-ci.org/OpenLiberty/liberty-arquillian.svg?branch=master)](https://travis-ci.org/OpenLiberty/liberty-arquillian)
 
-For Arquillian Liberty Managed container documentation, click [here](https://github.com/OpenLiberty/liberty-arquillian/tree/master/liberty-managed/README.md).
+[Arquillian](http://arquillian.org/) is a testing framework to develop automated functional, integration and acceptance tests for your Java applications. There are two types of Liberty `DeployableContainer` implementations; [Liberty Managed](#Arquillian-Liberty-Managed-Container) and [Liberty Remote](#Arquillian-Liberty-Remote-Container).
 
-For Arquillian Liberty Remote container documentation, click [here](https://github.com/OpenLiberty/liberty-arquillian/tree/master/liberty-remote/README.md).
+### Arquillian Liberty Mangaged Container
+
+An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM). For an introduction to testing microservices with the Arquillian Liberty Managed container and [Open Liberty](https://openliberty.io/), check out the [this guide](https://openliberty.io/guides/arquillian-managed.html).
+
+**Jakarta EE 9:** for Arquillian Liberty Managed container documentation with Jakarta EE 9, click [here](liberty-managed/JakartaEE9_README.md).
+
+**Java EE 8 or below:** for Arquillian Liberty Managed container documentation with Java EE 8 or below, click [here](liberty-managed/README.md).
+
+### Arquillian Liberty Remote Container
+
+An Arquillian container adapter (`DeployableContainer` implementation) that can connect and run against a remote (different JVM, different machine) Liberty server and run tests on it over a remote protocol (effectively in a different JVM).
+
+**Jakarta EE 9:** for Arquillian Liberty Remote container documentation with Jakarta EE 9, click [here](liberty-remote/JakartaEE9_README.md).
+
+**Java EE 8 or below:** for Arquillian Liberty Remote container documentation with Java EE 8 or below, click [here](liberty-remote/README.md).
 
 ### Testing
 
@@ -13,8 +27,8 @@ To run tests, you will need to specify the following parameters:
 | runtime          | The runtime to use. Specify `ol` for Open Liberty and `wlp` for WebSphere Liberty. |
 | runtimeVersion   | Version of the specified runtime to use. |
 
-For example, to run tests on version 18.0.0.1 of the Open Liberty runtime, use the following command:
+For example, to run tests on version 20.0.0.11 of the Open Liberty runtime, use the following command:
 
 ```
-mvn verify -Druntime=ol -DruntimeVersion=18.0.0.1
+mvn verify -Druntime=ol -DruntimeVersion=20.0.0.11
 ```

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -19,11 +19,11 @@ The following features are required in the `server.xml` of the Liberty server.
 <featureManager>
     <feature>jsp-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-1.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
+    <feature>usr:arquillian-support-jakarta-2.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
 </featureManager>
 ```
 
-Read more about configuring the `arquillian-support-1.0` feature [here](../liberty-support-feature/README.md).
+Read more about configuring the `arquillian-support-jakarta-2.0` feature [here](../liberty-support-feature/JakartaEE9_README.md).
 
 You will also need to enable the `applicationMonitor` MBean support in your `server.xml`:
 
@@ -44,7 +44,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha3</version>
+			<version>1.7.0.Alpha5</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -55,8 +55,8 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 	...
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
-		<artifactId>arquillian-liberty-managed</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<artifactId>arquillian-liberty-managed-jakarta</artifactId>
+		<version>2.0.0-M1</version>
 		<scope>test</scope>
 	</dependency>
 	...

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -1,14 +1,14 @@
-# Arquillian Liberty Managed
+# Arquillian Liberty Managed with Jakarta EE 9
 
-An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM).
+An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM). 
 
 ## Prerequisites
 
 **Prerequisite Version**
 
-This `DeployableContainer` has been tested with the latest two releases of Open Liberty and WebSphere Liberty. Requires Java EE 8 or below.
+This `DeployableContainer` has been tested with the latest beta release of Open Liberty. Requires Jakarta EE 9.
 
-For Jakarta EE 9 projects, check out the documentation [here](JakartaEE9_README.md).
+For Java EE 8 projects and below, check out the documentation [here](README.md).
 
 **Prerequisite Configuration**
 
@@ -17,9 +17,8 @@ The following features are required in the `server.xml` of the Liberty server.
 ```
 <!-- Enable features -->
 <featureManager>
-    <feature>jsp-2.3</feature>
+    <feature>jsp-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>j2eeManagement-1.1</feature> <!-- Optional, needed to allow injection on ArquillianResources related to servlets -->
     <feature>usr:arquillian-support-1.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
 </featureManager>
 ```
@@ -32,11 +31,11 @@ You will also need to enable the `applicationMonitor` MBean support:
 <applicationMonitor updateTrigger="mbean"/>
 ```
 
-If you need a sample server.xml, please refer to the [one in our source repository](https://github.com/OpenLiberty/liberty-arquillian/blob/arquillian-parent-liberty-1.0.6/liberty-managed/src/test/resources/server.xml).
+If you need a sample server.xml, please refer to the [one in our source repository](https://github.com/OpenLiberty/liberty-arquillian/blob/master/liberty-managed/src/test/resources/server.xml).
 
 ## Configuration
 
-Default Protocol: Servlet 3.0
+Default Protocol: Servlet 5.0
 
 To enable Arquillian Liberty Managed in your project, add the following to your `pom.xml`:
 ```xml
@@ -45,7 +44,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.4.0.Final</version>
+			<version>1.7.0.Alpha3</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -57,7 +56,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-managed</artifactId>
-		<version>1.0.6</version>
+		<version>1.0.7-SNAPSHOT</version>
 		<scope>test</scope>
 	</dependency>
 	...

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -25,7 +25,7 @@ The following features are required in the `server.xml` of the Liberty server.
 
 Read more about configuring the `arquillian-support-1.0` feature [here](../liberty-support-feature/README.md).
 
-You will also need to enable the `applicationMonitor` MBean support:
+You will also need to enable the `applicationMonitor` MBean support in your `server.xml`:
 
 ```
 <applicationMonitor updateTrigger="mbean"/>

--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -26,7 +26,7 @@ The following features are required in the `server.xml` of the Liberty server.
 
 Read more about configuring the `arquillian-support-1.0` feature [here](../liberty-support-feature/README.md).
 
-You will also need to enable the `applicationMonitor` MBean support:
+You will also need to enable the `applicationMonitor` MBean support in your `server.xml`:
 
 ```
 <applicationMonitor updateTrigger="mbean"/>

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -46,6 +46,32 @@ If you need a sample `server.xml`, please refer to the [one in our source reposi
 
 Default Protocol: Servlet 5.0
 
+To enable Arquillian Liberty Remote in your project, add the following to your `pom.xml`:
+```xml
+<dependencyManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.jboss.arquillian</groupId>
+			<artifactId>arquillian-bom</artifactId>
+			<version>1.7.0.Alpha5</version>
+			<scope>import</scope>
+			<type>pom</type>
+		</dependency>
+	</dependencies>
+</dependencyManagement>
+
+<dependencies>
+	...
+	<dependency>
+		<groupId>io.openliberty.arquillian</groupId>
+		<artifactId>arquillian-liberty-remote-jakarta</artifactId>
+		<version>2.0.0-M1</version>
+		<scope>test</scope>
+	</dependency>
+	...
+</dependencies>
+```
+
 **Container Configuration Options**
 
 | Name | Type | Default | Description |
@@ -89,15 +115,14 @@ xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/a
 ```
 
 ### Example of Maven profile setup
-
 ```
 <profile>
 	<id>liberty-remote</id>
 	<dependencies>
 		<dependency>
 			<groupId>io.openliberty.arquillian</groupId>
-			<artifactId>arquillian-liberty-remote</artifactId>
-			<version>1.0.0</version>
+			<artifactId>arquillian-liberty-remote-jakarta</artifactId>
+			<version>2.0.0-M1</version>
 		</dependency>
 	</dependencies>
 </profile>

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -1,14 +1,14 @@
-# Arquillian Liberty Remote
+# Arquillian Liberty Remote with Jakarta EE 9
 
-An Arquillian container adapter (`DeployableContainer` implementation) that can connect and run against a remote (different JVM, different machine) Liberty server and run tests on it over a remote protocol (effectively in a different JVM).
+An Arquillian container adapter (`DeployableContainer` implementation) that can connect and run against a remote (different JVM, different machine) Liberty server andrun tests on it over a remote protocol (effectively in a different JVM).
 
 ## Prerequisites
 
 **Prerequisite Version**
 
-This `DeployableContainer` has been tested with the latest two releases of Open Liberty and WebSphere Liberty. Requires Java EE 8 or below.
+This `DeployableContainer` has been tested with the latest beta release of Open Liberty. Requires Jakarta EE 9.
 
-For Jakarta EE 9 projects, check out the documentation [here](JakartaEE9_README.md).
+For Java EE 8 projects and below, check out the documentation [here](README.md).
 
 **Prerequisite Configuration**
 
@@ -17,8 +17,8 @@ The following features are required in the `server.xml` of the Liberty server.
 ```
 <!-- Enable features -->
 <featureManager>
-    <feature>jsp-2.3</feature>
-    <feature>restConnector-1.0</feature>
+    <feature>jsp-3.0</feature>
+    <feature>restConnector-2.0</feature>
 </featureManager>
 ```
 
@@ -40,37 +40,11 @@ the remote container adapter relies on this configuration -->
 </remoteFileAccess>
 ````
 
-If you need a sample server.xml, please refer to the [one in our source repository](https://github.com/OpenLiberty/liberty-arquillian/blob/arquillian-parent-liberty-1.0.6/liberty-remote/src/test/resources/server.xml).
+If you need a sample `server.xml`, please refer to the [one in our source repository](https://github.com/OpenLiberty/liberty-arquillian/blob/master/liberty-remote/src/test/resources/server.xml).
 
 ## Configuration
 
-Default Protocol: Servlet 3.0
-
-To enable Arquillian Liberty Remote in your project, add the following to your `pom.xml`:
-```xml
-<dependencyManagement>
-	<dependencies>
-		<dependency>
-			<groupId>org.jboss.arquillian</groupId>
-			<artifactId>arquillian-bom</artifactId>
-			<version>1.4.0.Final</version>
-			<scope>import</scope>
-			<type>pom</type>
-		</dependency>
-	</dependencies>
-</dependencyManagement>
-
-<dependencies>
-	...
-	<dependency>
-		<groupId>io.openliberty.arquillian</groupId>
-		<artifactId>arquillian-liberty-remote</artifactId>
-		<version>1.0.6</version>
-		<scope>test</scope>
-	</dependency>
-	...
-</dependencies>
-```
+Default Protocol: Servlet 5.0
 
 **Container Configuration Options**
 
@@ -112,4 +86,19 @@ xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/a
 		</configuration>
 	</container>
 </arquillian>
+```
+
+### Example of Maven profile setup
+
+```
+<profile>
+	<id>liberty-remote</id>
+	<dependencies>
+		<dependency>
+			<groupId>io.openliberty.arquillian</groupId>
+			<artifactId>arquillian-liberty-remote</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+	</dependencies>
+</profile>
 ```

--- a/liberty-support-feature/JakartaEE9_README.md
+++ b/liberty-support-feature/JakartaEE9_README.md
@@ -1,21 +1,22 @@
-# Arquillian support Liberty user feature
+# Arquillian support Liberty user feature with Jakarta EE 9
 
-A Liberty user feature which allows deployment exceptions to be reported more reliably when using the Liberty Managed container.
+A Liberty user feature which allows deployment exceptions to be reported more reliably when using the Liberty Managed Jakarta container.
 
 The Arquillian support feature adds an additional http endpoint which the Arquillian container can query to determine the cause when an application fails to start.
 
 It is only for supporting the running of Arquillian tests and must not be installed on a production system.
 
-Requires Java EE 8 or below. For Jakarta EE 9 projects, check out the documentation [here](JakartaEE9_README.md).
+Requires Jakarta EE 9. For Java EE 8 projects and below, check out the documentation [here](README.md).
+
 
 ## Usage
 
-1. Extract the arquillian-liberty-support-x.x.x-feature.zip into the `usr` directory of your Liberty runtime
-1. Add `<feature>usr:arquillian-support-1.0</feature>` to the `<featureManager>` section of your `server.xml`
+1. Extract the arquillian-liberty-support-jakarta-x.x.x-feature.zip into the `usr` directory of your Liberty runtime
+1. Add `<feature>usr:arquillian-support-jakarta-2.0</feature>` to the `<featureManager>` section of your `server.xml`
 
 ## Maven usage
 
-You can install the arquillian-liberty-support feature as part of a maven build using the [maven-dependency-plugin:unpack goal](https://maven.apache.org/plugins/maven-dependency-plugin/unpack-mojo.html)
+You can install the arquillian-liberty-support-jakarta feature as part of a maven build using the [maven-dependency-plugin:unpack goal](https://maven.apache.org/plugins/maven-dependency-plugin/unpack-mojo.html)
 
 Example:
 
@@ -36,8 +37,8 @@ Example:
         <artifactItems>
           <artifactItem>
             <groupId>io.openliberty.arquillian</groupId>
-            <artifactId>arquillian-liberty-support</artifactId>
-            <version>1.0.4</version>
+            <artifactId>arquillian-liberty-support-jakarta</artifactId>
+            <version>2.0.0-M1</version>
             <type>zip</type>
             <classifier>feature</classifier>
             <overWrite>false</overWrite>

--- a/liberty-support-feature/README.md
+++ b/liberty-support-feature/README.md
@@ -1,14 +1,14 @@
 # Arquillian support Liberty user feature
 
-A liberty user feature which allows deployment exceptions to be reported more reliably when using the liberty-managed container.
+A Liberty user feature which allows deployment exceptions to be reported more reliably when using the Liberty Managed container.
 
-The arquillian support feature adds an additional http endpoint which the arquillian container can query to determine the cause when an application fails to start.
+The Arquillian support feature adds an additional http endpoint which the Arquillian container can query to determine the cause when an application fails to start.
 
-It is only for supporting the running of arquillian tests and must not be installed on a production system.
+It is only for supporting the running of Arquillian tests and must not be installed on a production system.
 
 ## Usage
 
-1. Extract the arquillian-liberty-support-x.x.x-feature.zip into the `usr` directory of your liberty runtime
+1. Extract the arquillian-liberty-support-x.x.x-feature.zip into the `usr` directory of your Liberty runtime
 1. Add `<feature>usr:arquillian-support-1.0</feature>` to the `<featureManager>` section of your `server.xml`
 
 ## Maven usage

--- a/liberty-support-feature/README.md
+++ b/liberty-support-feature/README.md
@@ -1,6 +1,6 @@
 # Arquillian support Liberty user feature
 
-A liberty user feature which allows deployment exceptions to be reported more reliably when using the liberty-managed container
+A liberty user feature which allows deployment exceptions to be reported more reliably when using the liberty-managed container.
 
 The arquillian support feature adds an additional http endpoint which the arquillian container can query to determine the cause when an application fails to start.
 


### PR DESCRIPTION
Add links for:
- liberty managed with Jakarta EE 9
- liberty managed with Java EE 8 or below
- liberty remote with Jakarta EE 9
- liberty remote with Java EE 8 or below

The Jakarta EE 9 documentation currently states that it has been tested with the latest Open Liberty beta. To be updated again once there is an official release for Jakarta EE 9.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>
**Fixes**: #83 