### PR TITLE
Prepare for 2.0.0-M1 release with Jakarta suffix

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -4,8 +4,8 @@
   <!-- Parent -->
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
-    <artifactId>arquillian-parent-liberty</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <artifactId>arquillian-parent-liberty-jakarta</artifactId>
+    <version>2.0.0-M1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -13,9 +13,9 @@
   <modelVersion>4.0.0</modelVersion>
   
   <!-- Artifact Configuration -->
-  <artifactId>arquillian-liberty-managed</artifactId>
-  <name>Arquillian Container Liberty Managed</name>
-  <description>Liberty Managed Container integration for the Arquillian Project</description>
+  <artifactId>arquillian-liberty-managed-jakarta</artifactId>
+  <name>Arquillian Container Liberty Jakarta Managed</name>
+  <description>Jakarta Liberty Managed Container integration for the Arquillian Project</description>
 
   <properties>
     <skipTests>false</skipTests>
@@ -132,7 +132,7 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>${project.groupId}</groupId>
-                  <artifactId>arquillian-liberty-support</artifactId>
+                  <artifactId>arquillian-liberty-support-jakarta</artifactId>
                   <version>${project.version}</version>
                   <type>zip</type>
                   <classifier>feature</classifier>
@@ -312,7 +312,7 @@
     
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>arquillian-liberty-support</artifactId>
+      <artifactId>arquillian-liberty-support-jakarta</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.0.0-M1</version>
+    <version>2.0.0-M1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
@@ -28,7 +28,7 @@ import org.apache.http.client.utils.URIBuilder;
 /**
  * Tries to receive a serialized exception from the server
  * <p>
- * This relies on the liberty-support-feature being installed and running
+ * This relies on the liberty-support-jakarta-feature being installed and running
  * <p>
  * This is the best way to get the exception as it retains all of the exception
  * information from the server, including the stack trace, but will fail if any
@@ -42,7 +42,7 @@ public class SupportFeatureSerializedExceptionLocator implements DeploymentExcep
     
     public SupportFeatureSerializedExceptionLocator(String host, int port) {
         try {
-            uri = new URI("http", null, host, port, "/arquillian-support/deployment-exception", "format=serialize", null);
+            uri = new URI("http", null, host, port, "/arquillian-support-jakarta/deployment-exception", "format=serialize", null);
         } catch (URISyntaxException e) {
             // Shouldn't happen as most of the URI parts are hard coded
             throw new IllegalArgumentException("Invalid URI: " + e, e);
@@ -60,7 +60,7 @@ public class SupportFeatureSerializedExceptionLocator implements DeploymentExcep
             if (resp.getStatusLine().getStatusCode() == 400) {
                 log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
             } else if (resp.getStatusLine().getStatusCode() != 200) {
-                log.info("Unable to recieve serialized exception from server, is usr:arquillian-support-1.0 installed?");
+                log.info("Unable to recieve serialized exception from server, is usr:arquillian-support-jakarta-2.0 installed?");
             } else {
                 try (InputStream inStream = resp.getEntity().getContent()) {
                     ObjectInputStream objStream = new ObjectInputStream(inStream);

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
@@ -35,7 +35,7 @@ import io.openliberty.arquillian.managed.exceptions.NestedExceptionBuilder.ExMsg
 /**
  * Tries to receive information about an exception from the server in text form
  * <p>
- * This relies on the liberty-support-feature being installed and running
+ * This relies on the liberty-support-jakarta-feature being installed and running
  * <p>
  * The text format expected from the server includes information about the
  * exception and its cause chain.
@@ -84,7 +84,7 @@ public class SupportFeatureTextExceptionLocator implements DeploymentExceptionLo
     
     public SupportFeatureTextExceptionLocator(String host, int port) {
         try {
-            uri = new URI("http", null, host, port, "/arquillian-support/deployment-exception", "format=text", null);
+            uri = new URI("http", null, host, port, "/arquillian-support-jakarta/deployment-exception", "format=text", null);
         } catch (URISyntaxException e) {
             // Shouldn't happen as most of the URI parts are hard coded
             throw new IllegalArgumentException("Invalid URI: " + e, e);
@@ -102,7 +102,7 @@ public class SupportFeatureTextExceptionLocator implements DeploymentExceptionLo
             if (resp.getStatusLine().getStatusCode() == 400) {
                 log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
             } else if (resp.getStatusLine().getStatusCode() != 200) {
-                log.info("Unable to recieve text format exception from server, is usr:arquillian-support-1.0?");
+                log.info("Unable to recieve text format exception from server, is usr:arquillian-support-jakarta-2.0 installed?");
             } else {
                 log.finer("Reading exception returned from server");
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(resp.getEntity().getContent(), StandardCharsets.UTF_8))) {

--- a/liberty-managed/src/test/resources/server-with-management.xml
+++ b/liberty-managed/src/test/resources/server-with-management.xml
@@ -7,7 +7,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-3.0</feature>
         <feature>jndi-1.0</feature>
-        <feature>usr:arquillian-support-1.0</feature>
+        <feature>usr:arquillian-support-jakarta-2.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.0.0-M1</version>
+    <version>2.0.0-M1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>arquillian-liberty-remote-jakarta</artifactId>

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -2,15 +2,15 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
-    <artifactId>arquillian-parent-liberty</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <artifactId>arquillian-parent-liberty-jakarta</artifactId>
+    <version>2.0.0-M1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>arquillian-liberty-remote</artifactId>
+  <artifactId>arquillian-liberty-remote-jakarta</artifactId>
 
   <!-- Artifact Configuration -->
-  <name>Arquillian Container Liberty Remote</name>
-  <description>Liberty Remote Container integration for the Arquillian Project</description>
+  <name>Arquillian Container Liberty Jakarta Remote</name>
+  <description>Jakarta Liberty Remote Container integration for the Arquillian Project</description>
 
   <properties>
     <skipTests>false</skipTests>

--- a/liberty-support-feature/bnd.bnd
+++ b/liberty-support-feature/bnd.bnd
@@ -1,4 +1,4 @@
-Web-ContextPath: arquillian-support
+Web-ContextPath: arquillian-support-jakarta
 Import-Package: jakarta.servlet.*; version="5.0", \
   com.ibm.ws.container.service.app.deploy; version="[1.0, 3)", \
   *

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.0.0-M1</version>
+    <version>2.0.0-M1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -4,8 +4,8 @@
   <!-- Parent -->
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
-    <artifactId>arquillian-parent-liberty</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <artifactId>arquillian-parent-liberty-jakarta</artifactId>
+    <version>2.0.0-M1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -13,9 +13,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <!-- Artifact Configuration -->
-  <artifactId>arquillian-liberty-support</artifactId>
-  <name>Arquillian Container Liberty Support Feature</name>
-  <description>Liberty Feature to support integration for the Arquillian Project</description>
+  <artifactId>arquillian-liberty-support-jakarta</artifactId>
+  <name>Arquillian Container Liberty Support Jakarta Feature</name>
+  <description>Jakarta Liberty Feature to support integration for the Arquillian Project</description>
 
   <build>
     <plugins>

--- a/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
+++ b/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
@@ -1,11 +1,11 @@
 IBM-Feature-Version: 2
-IBM-ShortName: arquillian-support-1.0
-Subsystem-Content: arquillian-liberty-support; version=${parsedVersion.osgiVersion},
+IBM-ShortName: arquillian-support-jakarta-2.0
+Subsystem-Content: arquillian-liberty-support-jakarta; version=${parsedVersion.osgiVersion},
  com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
  com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="5.0"; type="osgi.subsystem.feature"
-Subsystem-Description: Liberty Feature to support integration for the Arquillian Project
+Subsystem-Description: Jakarta Liberty Feature to support integration for the Arquillian Project
 Subsystem-ManifestVersion: 1
-Subsystem-Name: Arquillian Support Feature
-Subsystem-SymbolicName: io.openliberty.arquillian.arquillian-support-1.0; visibility:=public
+Subsystem-Name: Arquillian Support Jakarta Feature
+Subsystem-SymbolicName: io.openliberty.arquillian.arquillian-support-jakarta-2.0; visibility:=public
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: ${parsedVersion.osgiVersion}

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,11 @@
 
   <!-- Artifact Configuration -->
   <groupId>io.openliberty.arquillian</groupId>
-  <artifactId>arquillian-parent-liberty</artifactId>
-  <version>1.0.7-SNAPSHOT</version>
+  <artifactId>arquillian-parent-liberty-jakarta</artifactId>
+  <version>2.0.0-M1</version>
   <packaging>pom</packaging>
-  <name>Arquillian Container Liberty Parent</name>
-  <description>Liberty Container integrations for the Arquillian Project</description>
+  <name>Arquillian Container Liberty Jakarta Parent</name>
+  <description>Jakarta Liberty Container integrations for the Arquillian Project</description>
 
   <licenses>
     <license>
@@ -38,7 +38,7 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.7.0.Alpha3</version.arquillian_core>
+    <version.arquillian_core>1.7.0.Alpha5</version.arquillian_core>
     <version.surefire.plugin>2.21.0</version.surefire.plugin>
 
     <!-- override from parent -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <!-- Artifact Configuration -->
   <groupId>io.openliberty.arquillian</groupId>
   <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-  <version>2.0.0-M1</version>
+  <version>2.0.0-M1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Arquillian Container Liberty Jakarta Parent</name>
   <description>Jakarta Liberty Container integrations for the Arquillian Project</description>


### PR DESCRIPTION
bump version for 2.0.0.M1 release, updates artifact ids to:
- arquillian-liberty-managed-jakarta
- arquillian-liberty-remote-jakarta
- arquillian-liberty-support-jakarta

Now to specify the arquillian-liberty-support-feature in the server.xml:
```
 <feature>usr:arquillian-support-jakarta-2.0</feature>
```
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>
