### PR TITLE
Add httpclient dependency

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -263,6 +263,12 @@
           <artifactId>fluent-hc</artifactId>
           <version>4.5.6</version>
         </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>4.5.13</version>
+        </dependency>
+
 
 
         <!-- Jakarta EE Spec APIs -->


### PR DESCRIPTION
Add the `org.apache.httpcomponents:httpclient` dependency to resolve the `java.lang.NoClassDefFoundError: org/apache/http/client/utils/URIBuilder` error

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>

