### PR TITLE
Detect servlets from ClassLoaderAssets

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -268,8 +268,11 @@
           <artifactId>httpclient</artifactId>
           <version>4.5.13</version>
         </dependency>
-
-
+        <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>2.8.0</version>
+        </dependency>
 
         <!-- Jakarta EE Spec APIs -->
         <dependency>

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/ByteClassLoader.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/ByteClassLoader.java
@@ -18,7 +18,7 @@ package io.openliberty.arquillian.managed;
 public class ByteClassLoader extends ClassLoader {
 
     public Class<?> defineClass(String name, byte[] ba) throws IllegalAccessError {
-        return defineClass(name,ba,0,ba.length);
+        return defineClass(name, ba, 0, ba.length);
     }
 
 }

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/ByteClassLoader.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/ByteClassLoader.java
@@ -17,7 +17,7 @@ package io.openliberty.arquillian.managed;
 // Loads a class from a byte array
 public class ByteClassLoader extends ClassLoader {
 
-    public Class<?> defineClass(String name, byte[] ba) {
+    public Class<?> defineClass(String name, byte[] ba) throws IllegalAccessError {
         return defineClass(name,ba,0,ba.length);
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Classes can be registered as ClassLoaderAsset objects. Add a fix to load ClassLoaderAssets located in the WEB-INF dir and check if any of them are servlets. 

#### Changes proposed in this pull request:
- Add commons-io dependency
- Detect servlets from ClassLoaderAssets located in the WEB-INF dir