### PR TITLE
Fix serverName check and README docs for 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ To run tests, you will need to specify the following parameters:
 | runtime          | The runtime to use. Specify `ol` for Open Liberty and `wlp` for WebSphere Liberty. |
 | runtimeVersion   | Version of the specified runtime to use. |
 
-For example, to run tests on version 18.0.0.1 of the Open Liberty runtime, use the following command:
+For example, to run tests on version 21.0.0.3 of the Open Liberty runtime, use the following command:
 
 ```
-mvn verify -Druntime=ol -DruntimeVersion=18.0.0.1
+mvn verify -Druntime=ol -DruntimeVersion=21.0.0.3
 ```

--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -15,7 +15,7 @@ The following features are required in the `server.xml` of the Liberty server.
 ```
 <!-- Enable features -->
 <featureManager>
-    <feature>jsp-2.2</feature>
+    <feature>jsp-2.3</feature>
     <feature>localConnector-1.0</feature>
     <feature>j2eeManagement-1.1</feature> <!-- Optional, needed to allow injection on ArquillianResources related to servlets -->
     <feature>usr:arquillian-support-1.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2012, 2021, IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,8 +74,10 @@ public class WLPManagedContainerConfiguration implements
     		  throw new ConfigurationException("securityConfiguration provided is not valid: " + securityConfiguration);
       }
 
-      // Validate serverName
-      if (!serverName.matches("^[A-Za-z][A-Za-z0-9]*$"))
+      // Validate serverName 
+      // Use only Unicode alphanumeric (e.g. 0-9, a-z, A-Z), underscore (_), dash (-), plus (+), and period (.) characters.
+      // Do not begin with a dash (-) or a period (.).
+      if (!serverName.matches("^[A-Za-z0-9\\+_][A-Za-z0-9\\+_\\.-]*$"))
          throw new ConfigurationException("serverName provided is not valid: '" + serverName + "'");
 
       // Validate httpPort

--- a/liberty-remote/README.md
+++ b/liberty-remote/README.md
@@ -15,8 +15,8 @@ The following features are required in the `server.xml` of the Liberty server.
 ```
 <!-- Enable features -->
 <featureManager>
-    <feature>jsp-2.2</feature>
-    <feature>restConnector-1.0</feature>
+    <feature>jsp-2.3</feature>
+    <feature>restConnector-2.0</feature>
 </featureManager>
 ```
 


### PR DESCRIPTION
Fixes #98 and #99

#### Short description of what this resolves:
Fixes the serverName check to honor allowed characters and update README documentation.

#### Changes proposed in this pull request:

- Use correct regex for allowed characters in serverName.
- Update README documentation to reference correct version of features.
