### PR TITLE
Fix master branch name references for 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Arquillian Liberty Server Containers [![Maven Central Latest](https://maven-badges.herokuapp.com/maven-central/io.openliberty.arquillian/arquillian-parent-liberty/badge.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.openliberty.arquillian%22%20AND%20a%3A%22arquillian-parent-liberty%22) [![Build Status](https://travis-ci.org/OpenLiberty/liberty-arquillian.svg?branch=master)](https://travis-ci.org/OpenLiberty/liberty-arquillian)
+# Arquillian Liberty Server Containers [![Maven Central Latest](https://maven-badges.herokuapp.com/maven-central/io.openliberty.arquillian/arquillian-parent-liberty/badge.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.openliberty.arquillian%22%20AND%20a%3A%22arquillian-parent-liberty%22) [![Build Status 1.x](https://github.com/OpenLiberty/liberty-arquillian/actions/workflows/maven.yml/badge.svg?branch=1.x-maintenance)](https://github.com/OpenLiberty/liberty-arquillian/actions?branch=1.x-maintenance)
 
-For Arquillian Liberty Managed container documentation, click [here](https://github.com/OpenLiberty/liberty-arquillian/tree/master/liberty-managed/README.md).
+For Arquillian Liberty Managed container documentation, click [here](https://github.com/OpenLiberty/liberty-arquillian/tree/main/liberty-managed/README.md).
 
-For Arquillian Liberty Remote container documentation, click [here](https://github.com/OpenLiberty/liberty-arquillian/tree/master/liberty-remote/README.md).
+For Arquillian Liberty Remote container documentation, click [here](https://github.com/OpenLiberty/liberty-arquillian/tree/main/liberty-remote/README.md).
 
 ### Testing
 

--- a/liberty-remote/README.md
+++ b/liberty-remote/README.md
@@ -38,7 +38,7 @@ the remote container adapter relies on this configuration -->
 </remoteFileAccess>
 ````
 
-If you need a sample `server.xml`, please refer to the [one in our source repository](https://github.com/OpenLiberty/liberty-arquillian/blob/master/liberty-remote/src/test/resources/server.xml).
+If you need a sample `server.xml`, please refer to the [one in our source repository](https://github.com/OpenLiberty/liberty-arquillian/blob/main/liberty-remote/src/test/resources/server.xml).
 
 ## Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>https://raw.github.com/OpenLiberty/liberty-arquillian/master/LICENSE</url>
+      <url>https://raw.github.com/OpenLiberty/liberty-arquillian/main/LICENSE</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
#### Short description of what this resolves:
Fix references to master branch due to rename to main branch.

#### Changes proposed in this pull request:

- Fixed references in README docs.
- Fixed references in pom.xml.