### PR TITLE
Set WLP_USER_DIR for all process builders

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2012, 2021, IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -342,6 +342,14 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
      */
     private Thread getShutDownThread(final List<String> cmd) {
        final ProcessBuilder shutDownProcessBuilder = new ProcessBuilder(cmd);
+
+       try {
+          if (containerConfiguration.getUsrDir() != null) {
+             shutDownProcessBuilder.environment().put(WLP_USER_DIR, new File(containerConfiguration.getUsrDir()).getCanonicalPath());
+          }
+       } catch (IOException e) {
+          log.finer("Failed to set WLP_USER_DIR for shut-down shell command.");
+       }
 
        return new Thread(new Runnable() {
             @Override
@@ -1165,6 +1173,15 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
          // First run "server stop"
          ProcessBuilder stopProcessBuilder = new ProcessBuilder(getServerCommand(CommandType.STOP));
          stopProcessBuilder.redirectErrorStream(true);
+
+         try {
+            if (containerConfiguration.getUsrDir() != null) {
+               stopProcessBuilder.environment().put(WLP_USER_DIR, new File(containerConfiguration.getUsrDir()).getCanonicalPath());
+            }
+         } catch (IOException e) {
+            throw new LifecycleException("Failed to run server stop command", e);
+         }
+
          try {
             Process stopProcess = stopProcessBuilder.start();
             new Thread(new ConsoleConsumer(stopProcess)).start();


### PR DESCRIPTION
#### Short description of what this resolves:
Fix setting of WLP_USER_DIR for stop server commands.

#### Changes proposed in this pull request:

- Set the WLP_USER_DIR environment variable for the ProcessBuilder for the stop server commands.

Fixes #107 
