### PR TITLE
Tolerate `servlet-6.0` / EE10

### DIFF
--- a/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
+++ b/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
@@ -2,7 +2,7 @@ IBM-Feature-Version: 2
 IBM-ShortName: arquillian-support-jakarta-2.0
 Subsystem-Content: arquillian-liberty-support-jakarta; version=${parsedVersion.osgiVersion},
  com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="5.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="5.0,6.0"; type="osgi.subsystem.feature"
 Subsystem-Description: Jakarta Liberty Feature to support integration for the Arquillian Project
 Subsystem-ManifestVersion: 1
 Subsystem-Name: Arquillian Support Jakarta Feature


### PR DESCRIPTION

#### Short description of what this resolves:

Adds toleration of version "6.0" to the servlet feature. This should help enable EE10 development.

#### Changes proposed in this pull request:

-
-
-


**Fixes**: #113
