### PR TITLE
Update Arquillian support feature to not depend on servlet feature

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java: [1.8, 11]
         runtime: [ol]
-        runtime_version: [21.0.0.4-beta]
+        runtime_version: [22.0.0.6]
 
     steps:
     - uses: actions/checkout@v2

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
           <groupId>jakarta.annotation</groupId>
           <artifactId>jakarta.annotation-api</artifactId>
-          <version>2.0.0-RC1</version>
+          <version>2.0.0</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -258,16 +258,6 @@
           <scope>test</scope>
         </dependency>
 
-        <dependency>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>fluent-hc</artifactId>
-          <version>4.5.6</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-          <version>4.5.13</version>
-        </dependency>
         <dependency>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2021, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2012, 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,15 +24,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.ProcessBuilder.Redirect;
-import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,7 +50,6 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-import javax.swing.text.html.MinimalHTMLWriter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -79,15 +75,12 @@ import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
 import org.jboss.arquillian.container.test.api.Testable;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
-import org.jboss.shrinkwrap.api.Filter;
-import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.asset.ClassAsset;
 import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 import org.w3c.dom.DOMException;
@@ -471,8 +464,8 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
        try {
           // Attempt to find the exception that occurred on the server
           exceptionLocators = new ArrayList<>();
-          exceptionLocators.add(new SupportFeatureSerializedExceptionLocator("localhost", getHttpPort()));
-          exceptionLocators.add(new SupportFeatureTextExceptionLocator("localhost", getHttpPort()));
+          exceptionLocators.add(new SupportFeatureSerializedExceptionLocator(mbsc));
+          exceptionLocators.add(new SupportFeatureTextExceptionLocator(mbsc));
           exceptionLocators.add(new FFDCExceptionLocator(getLogsDirectory()));
           exceptionLocators.add(new CDILogExceptionLocator());
        } catch (Exception e) {

--- a/liberty-support-feature/bnd.bnd
+++ b/liberty-support-feature/bnd.bnd
@@ -1,5 +1,6 @@
 Web-ContextPath: arquillian-support-jakarta
-Import-Package: jakarta.servlet.*; version="5.0", \
+Import-Package: \
   com.ibm.ws.container.service.app.deploy; version="[1.0, 3)", \
   *
+Bundle-Activator: io.openliberty.arquillian.support.Initializer
 Bundle-Version: ${parsedVersion.osgiVersion}

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -116,12 +116,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>5.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
       <version>6.0.0</version>

--- a/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
+++ b/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
@@ -1,8 +1,7 @@
 IBM-Feature-Version: 2
 IBM-ShortName: arquillian-support-jakarta-2.0
 Subsystem-Content: arquillian-liberty-support-jakarta; version=${parsedVersion.osgiVersion},
- com.ibm.wsspi.appserver.webBundle-1.0; type="osgi.subsystem.feature",
- com.ibm.websphere.appserver.servlet-5.0; ibm.tolerates:="5.0,6.0"; type="osgi.subsystem.feature"
+ com.ibm.websphere.appserver.localConnector-1.0; type="osgi.subsystem.feature"
 Subsystem-Description: Jakarta Liberty Feature to support integration for the Arquillian Project
 Subsystem-ManifestVersion: 1
 Subsystem-Name: Arquillian Support Jakarta Feature

--- a/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/DeploymentExceptionMBean.java
+++ b/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/DeploymentExceptionMBean.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openliberty.arquillian.support;
+
+import javax.management.MBeanException;
+
+public interface DeploymentExceptionMBean {
+
+    public Object[] getDeploymentException(String appName, String format) throws MBeanException;
+
+    public void clear();
+}

--- a/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/Initializer.java
+++ b/liberty-support-feature/src/main/java/io/openliberty/arquillian/support/Initializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2018, 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,14 +14,15 @@
  */
 package io.openliberty.arquillian.support;
 
+import java.lang.management.ManagementFactory;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
-import jakarta.servlet.annotation.WebListener;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 
+import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceRegistration;
@@ -29,36 +30,52 @@ import org.osgi.framework.ServiceRegistration;
 import com.ibm.ws.container.service.state.ApplicationStateListener;
 import com.ibm.ws.ffdc.FFDC;
 
-@WebListener
-public class Initializer implements ServletContextListener {
-    
-    public static final String INCIDENT_LISTENER_ATTRIBUTE = "incident-listener";
-    public static final String BUNDLE_CONTEXT_ATTRIBUTE = "osgi-bundlecontext"; //OSGi 6.0 enterprise, 128.6.1
-    
-    private ServiceRegistration<ApplicationStateListener> appStateListenerRegistration;
+public class Initializer implements BundleActivator {
+
+    private static final ObjectName on;
+
+    static {
+        StringBuilder sb = new StringBuilder("LibertyArquillian:");
+        sb.append("type=").append("DeploymentExceptionMBean");
+        try {
+            on = new ObjectName(sb.toString());
+        } catch (MalformedObjectNameException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+	private ServiceRegistration<ApplicationStateListener> appStateListenerRegistration;
+
+    private IncidentListener listener = new IncidentListener();
 
     @Override
-    public void contextInitialized(ServletContextEvent sce) {
+    public void start(BundleContext bContext) {
         // Register the listener as an incident forwarder
-        ServletContext context = sce.getServletContext();
-        IncidentListener listener = new IncidentListener();
-        context.setAttribute(INCIDENT_LISTENER_ATTRIBUTE, listener);
         FFDC.registerIncidentForwarder(listener);
         
         // Register the listener as an ApplicationStateListener
-        BundleContext bContext = (BundleContext) context.getAttribute(BUNDLE_CONTEXT_ATTRIBUTE);
         Dictionary<String, Object> properties = new Hashtable<>();
         // Big number for the ranking so we get called early.
         // Other components use this event to initialize things for the app and may throw validation exceptions,
         // we need to know the app that's starting before an exception is thrown
         properties.put(Constants.SERVICE_RANKING, 5000); 
         appStateListenerRegistration = bContext.registerService(ApplicationStateListener.class, listener, properties);
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        try {
+            mbs.registerMBean(new DeploymentExceptionMBeanImpl(listener), on);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
-    public void contextDestroyed(ServletContextEvent sce) {
-        ServletContext context = sce.getServletContext();
-        IncidentListener listener = (IncidentListener) context.getAttribute(INCIDENT_LISTENER_ATTRIBUTE);
+    public void stop(BundleContext ctx) {
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        try {
+            mbs.unregisterMBean(on);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         FFDC.deregisterIncidentForwarder(listener);
         appStateListenerRegistration.unregister();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -118,9 +118,9 @@
       </activation>
       <properties>
         <runtime>ol</runtime>
-        <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
+        <runtimeGroupId>io.openliberty</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>21.0.0.4-beta</runtimeVersion>
+        <runtimeVersion>22.0.0.6</runtimeVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
- Update to use JMX instead of a servlet to get the Exception data from the server so that we do not need to enable the servlet feature since it is not required by the Core Profile.


**Fixes**: #113
