### PR TITLE
Use the new REST protocol option to not depend on servlet to run tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java: [1.8, 11]
         runtime: [ol]
-        runtime_version: [22.0.0.6]
+        runtime_version: [22.0.0.9-beta]
 
     steps:
     - uses: actions/checkout@v2

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -19,11 +19,22 @@ The following features are required in the `server.xml` of the Liberty server.
 <featureManager>
     <feature>pages-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-jakarta-2.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
+    <feature>usr:arquillian-support-jakarta-2.1</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
 </featureManager>
 ```
 
-Read more about configuring the `arquillian-support-jakarta-2.0` feature [here](../liberty-support-feature/JakartaEE9_README.md).
+or
+
+```
+<!-- Enable features -->
+<featureManager>
+    <feature>restfulWS-3.0</feature>
+    <feature>localConnector-1.0</feature>
+    <feature>usr:arquillian-support-jakarta-2.1</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
+</featureManager>
+```
+
+Read more about configuring the `arquillian-support-jakarta-2.1` feature [here](../liberty-support-feature/JakartaEE9_README.md).
 
 You will also need to enable the `applicationMonitor` MBean support in your `server.xml`:
 
@@ -35,16 +46,17 @@ If you need a sample server.xml, please refer to the [one in our source reposito
 
 ## Configuration
 
-Default Protocol: Servlet 5.0
+Default Protocol: Servlet 5.0 or REST 3.0 depend on configuration
 
 To enable Arquillian Liberty Managed in your project, add the following to your `pom.xml`:
+
 ```xml
 <dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha9</version>
+			<version>1.7.0.Alpha12</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -56,7 +68,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-managed-jakarta</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0</version>
 		<scope>test</scope>
 	</dependency>
 	...
@@ -86,6 +98,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 | outputToConsole | Boolean | true | When enabled output from the application server process will be emitted to stdout |
 | fileDeleteRetries | Integer | 30 | How many times to attempt deleting a file |
 | standardFileDeleteRetryInterval | Integer | 50 | How long in milliseconds to wait between attempting to delete a file |
+| testProtocol | String | servlet | Aquillian protocol to contact the server to run a test (available: servlet or rest) |
 
 
 ## Examples

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,6 +40,9 @@
       <activation>
         <jdk>[1.0,1.9)</jdk>
       </activation>
+      <properties>
+        <skipEE10Tests>true</skipEE10Tests>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>com.sun</groupId>
@@ -55,6 +58,9 @@
       <activation>
           <jdk>[11,)</jdk>
       </activation>
+      <properties>
+        <skipEE10Tests>false</skipEE10Tests>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>jakarta.annotation</groupId>
@@ -97,7 +103,7 @@
                  </configuration>
                  <goals>
                   <goal>create</goal>
-                </goals>
+                 </goals>
           </execution>
           <execution>
             <id>create-server-management</id>
@@ -108,13 +114,55 @@
                  <configuration>
                   <serverName>managementServer</serverName>
                   <serverXmlFile>src/test/resources/server-with-management.xml</serverXmlFile>
-                </configuration>
-                <goals>
+                 </configuration>
+                 <goals>
                   <goal>create</goal>
                 </goals>
-              </execution>
-            </executions>
-          </plugin>
+          </execution>
+          <execution>
+            <id>create-rest-server</id>
+            <!-- Plugin execution only succeeds here in the correct order because
+                 execution id of the test is not 'default-test'.
+                 Because Maven. See MNG-5799 and MNG-5987 -->
+                 <phase>test</phase>
+                 <configuration>
+                  <serverName>restServer</serverName>
+                  <serverXmlFile>src/test/resources/restServer.xml</serverXmlFile>
+                 </configuration>
+                 <goals>
+                  <goal>create</goal>
+                 </goals>
+          </execution>
+          <execution>
+            <id>create-rest-server-management</id>
+            <!-- Plugin execution only succeeds here in the correct order because
+                 execution id of the test is not 'default-test'.
+                 Because Maven. See MNG-5799 and MNG-5987 -->
+                 <phase>test</phase>
+                 <configuration>
+                  <serverName>managementRestServer</serverName>
+                  <serverXmlFile>src/test/resources/restServer-with-management.xml</serverXmlFile>
+                 </configuration>
+                 <goals>
+                  <goal>create</goal>
+                 </goals>
+          </execution>
+          <execution>
+            <id>create-rest-server-management-ee10</id>
+            <!-- Plugin execution only succeeds here in the correct order because
+                 execution id of the test is not 'default-test'.
+                 Because Maven. See MNG-5799 and MNG-5987 -->
+                 <phase>test</phase>
+                 <configuration>
+                  <serverName>managementRestServer-ee10</serverName>
+                  <serverXmlFile>src/test/resources/restServer-with-management-ee10.xml</serverXmlFile>
+                 </configuration>
+                 <goals>
+                  <goal>create</goal>
+                 </goals>
+          </execution>
+        </executions>
+        </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
@@ -159,17 +207,17 @@
             </configuration>
             <executions>
               <execution>
-                <id>wlp-dropins-deployment-test</id>
+                <id>wlp-dropins-deployment-servlet-test</id>
                 <phase>test</phase>
                 <goals>
                   <goal>test</goal>
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
-                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-dropins-deployment-test
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-dropins-deployment-servlet-test
                   </reportsDirectory>
                   <systemPropertyVariables>
-                    <arquillian.launch>wlp-dropins-deployment</arquillian.launch>
+                    <arquillian.launch>wlp-dropins-deployment-servlet</arquillian.launch>
                   </systemPropertyVariables>
                   <excludes>
                     <exclude>**/needsmanagementmbeans/**</exclude>
@@ -178,16 +226,16 @@
                 </configuration>
               </execution>
               <execution>
-                <id>wlp-xml-deployment-test</id>
+                <id>wlp-xml-deployment-servlet-test</id>
                 <phase>test</phase>
                 <goals>
                   <goal>test</goal>
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
-                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-deployment-test</reportsDirectory>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-deployment-servlet-test</reportsDirectory>
                   <systemPropertyVariables>
-                    <arquillian.launch>wlp-xml-deployment</arquillian.launch>
+                    <arquillian.launch>wlp-xml-deployment-servlet</arquillian.launch>
                   </systemPropertyVariables>
                   <excludes>
                     <exclude>**/needsmanagementmbeans/**</exclude>
@@ -196,17 +244,88 @@
                 </configuration>
               </execution>
               <execution>
-                <id>wlp-xml-management-deployment-test</id>
+                <id>wlp-xml-management-deployment-servlet-test</id>
                 <phase>test</phase>
                 <goals>
                   <goal>test</goal>
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
-                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-test</reportsDirectory>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-servlet-test</reportsDirectory>
                   <systemPropertyVariables>
-                    <arquillian.launch>wlp-xml-management-deployment</arquillian.launch>
+                    <arquillian.launch>wlp-xml-management-deployment-servlet</arquillian.launch>
                   </systemPropertyVariables>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>wlp-dropins-deployment-rest-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-dropins-deployment-rest-test
+                  </reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-dropins-deployment-rest</arquillian.launch>
+                  </systemPropertyVariables>
+                  <excludes>
+                    <exclude>**/needsmanagementmbeans/**</exclude>
+                    <exclude>**/needssupportfeature/**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>wlp-xml-deployment-rest-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-deployment-rest-test</reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-xml-deployment-rest</arquillian.launch>
+                  </systemPropertyVariables>
+                  <excludes>
+                    <exclude>**/needsmanagementmbeans/**</exclude>
+                    <exclude>**/needssupportfeature/**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>wlp-xml-management-deployment-rest-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-rest-test</reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-xml-management-deployment-rest</arquillian.launch>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>wlp-xml-management-deployment-rest-ee10-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <skip>${skipEE10Tests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-rest-ee10-test</reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-xml-management-deployment-rest-ee10</arquillian.launch>
+                  </systemPropertyVariables>
+                  <includes>
+                    <include>**/needssupportfeature/**</include>
+                  </includes>
                 </configuration>
               </execution>
 
@@ -226,6 +345,10 @@
         <dependency>
           <groupId>org.jboss.arquillian.container</groupId>
           <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.arquillian.protocol</groupId>
+          <artifactId>arquillian-protocol-rest-jakarta</artifactId>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
@@ -283,8 +406,6 @@
           <artifactId>jakarta.enterprise.cdi-api</artifactId>
           <version>3.0.0</version>
         </dependency>
-
-        
 
     <!-- WELD classes, these are present in FFDC
     and are sometimes instances of TCK @ShouldThrow exceptions -->

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2021, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2012, 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +45,7 @@ public class WLPManagedContainerConfiguration implements
    private int verifyAppDeployTimeout = appDeployTimeout;
    private int fileDeleteRetries = 30; 
    private int standardFileDeleteRetryInterval = 50;
+   private String testProtocol = "servlet";
 
    @Override
    public void validate() throws ConfigurationException {
@@ -110,6 +111,10 @@ public class WLPManagedContainerConfiguration implements
 
       if (standardFileDeleteRetryInterval < 0) {
          throw new ConfigurationException("standardFileDeleteRetryInterval cannot be negative");
+      }
+
+      if (!"rest".equalsIgnoreCase(testProtocol) && !"servlet".equalsIgnoreCase(testProtocol)) {
+          throw new ConfigurationException("testProtocol must be set to rest or servlet");
       }
    }
 
@@ -296,4 +301,15 @@ public class WLPManagedContainerConfiguration implements
       this.standardFileDeleteRetryInterval = standardFileDeleteRetryInterval;
    }
 
+   public String getTestProtocol() {
+       return testProtocol;
+   }
+
+   public void setTestProtocol(String protocol) {
+       this.testProtocol = protocol;
+   }
+
+   public boolean isServletTestProtocol() {
+       return "servlet".equalsIgnoreCase(testProtocol);
+   }
 }

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
@@ -62,7 +62,7 @@ public class SupportFeatureSerializedExceptionLocator implements DeploymentExcep
             if (status == 400) {
                 log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
             } else if (status != 200) {
-                log.info("Unable to receive serialized exception from server, is usr:arquillian-support-jakarta-2.0 installed?");
+                log.info("Unable to receive serialized exception from server, is usr:arquillian-support-jakarta-2.1 installed?");
             } else {
                 try (InputStream inStream = new ByteArrayInputStream((byte[]) response[1])) {
                     ObjectInputStream objStream = new ObjectInputStream(inStream);

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
@@ -102,7 +102,7 @@ public class SupportFeatureTextExceptionLocator implements DeploymentExceptionLo
             if (status == 400) {
                 log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
             } else if (status != 200) {
-                log.info("Unable to receive text format exception from server, is usr:arquillian-support-jakarta-2.0 installed?");
+                log.info("Unable to receive text format exception from server, is usr:arquillian-support-jakarta-2.1 installed?");
             } else {
                 log.finer("Reading exception returned from server");
                 try (BufferedReader reader = new BufferedReader(new StringReader((String) response[1]))) {

--- a/liberty-managed/src/test/resources/arquillian.xml
+++ b/liberty-managed/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
     <property name="deploymentExportPath">target/</property>
   </engine>
 
-  <container qualifier="wlp-dropins-deployment" default="true">
+  <container qualifier="wlp-dropins-deployment-servlet" default="true">
     <configuration>
       <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
       <property name="deployType">dropins</property>
@@ -17,7 +17,7 @@
       <property name="appUndeployTimeout">10</property>
     </configuration>
   </container>
-  <container qualifier="wlp-xml-deployment">
+  <container qualifier="wlp-xml-deployment-servlet">
     <configuration>
       <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
       <property name="httpPort">9080</property>
@@ -32,7 +32,7 @@
       <property name="appUndeployTimeout">10</property>
     </configuration>
   </container>
-  <container qualifier="wlp-xml-management-deployment">
+  <container qualifier="wlp-xml-management-deployment-servlet">
     <configuration>
       <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
       <property name="deployType">xml</property>
@@ -44,4 +44,59 @@
     </configuration>
   </container>
   
+  <container qualifier="wlp-dropins-deployment-rest">
+    <configuration>
+      <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
+      <property name="deployType">dropins</property>
+      <property name="serverName">restServer</property>
+      <property name="testProtocol">rest</property>
+
+      <!-- Adjust timeouts to work on Cloudbees CI server -->
+      <property name="appDeployTimeout">60</property>
+      <property name="appUndeployTimeout">10</property>
+    </configuration>
+  </container>
+  <container qualifier="wlp-xml-deployment-rest">
+    <configuration>
+      <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
+      <property name="httpPort">9080</property>
+      <property name="deployType">xml</property>
+      <property name="serverName">restServer</property>
+      <property name="testProtocol">rest</property>
+      <property name="javaVmArguments">-Xmx512m</property>
+      <!-- the values below are the documented default, so it is not changing anything,
+           other than testing these code paths -->
+      <property name="apiTypeVisibility">spec, ibm-api, api</property>
+
+      <!-- Adjust timeouts to work on Cloudbees CI server -->
+      <property name="appDeployTimeout">60</property>
+      <property name="appUndeployTimeout">10</property>
+    </configuration>
+  </container>
+  <container qualifier="wlp-xml-management-deployment-rest">
+    <configuration>
+      <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
+      <property name="deployType">xml</property>
+      <property name="serverName">managementRestServer</property>
+      <property name="testProtocol">rest</property>
+
+      <!-- Adjust timeouts to work on Cloudbees CI server -->
+      <property name="appDeployTimeout">60</property>
+      <property name="appUndeployTimeout">10</property>
+    </configuration>
+  </container>
+
+  <container qualifier="wlp-xml-management-deployment-rest-ee10">
+    <configuration>
+      <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
+      <property name="deployType">xml</property>
+      <property name="serverName">managementRestServer-ee10</property>
+      <property name="testProtocol">rest</property>
+
+      <!-- Adjust timeouts to work on Cloudbees CI server -->
+      <property name="appDeployTimeout">60</property>
+      <property name="appUndeployTimeout">10</property>
+    </configuration>
+  </container>
+
 </arquillian>

--- a/liberty-managed/src/test/resources/restServer-with-management-ee10.xml
+++ b/liberty-managed/src/test/resources/restServer-with-management-ee10.xml
@@ -3,9 +3,9 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>pages-3.0</feature>
+        <feature>restfulWS-3.1</feature>
         <feature>localConnector-1.0</feature>
-        <feature>cdi-3.0</feature>
+        <feature>cdi-4.0</feature>
         <feature>jndi-1.0</feature>
         <feature>usr:arquillian-support-jakarta-2.1</feature>
     </featureManager>

--- a/liberty-managed/src/test/resources/restServer-with-management.xml
+++ b/liberty-managed/src/test/resources/restServer-with-management.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>pages-3.0</feature>
+        <feature>restfulWS-3.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>cdi-3.0</feature>
         <feature>jndi-1.0</feature>

--- a/liberty-managed/src/test/resources/restServer.xml
+++ b/liberty-managed/src/test/resources/restServer.xml
@@ -3,11 +3,10 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>pages-3.0</feature>
+        <feature>restfulWS-3.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>cdi-3.0</feature>
         <feature>jndi-1.0</feature>
-        <feature>usr:arquillian-support-jakarta-2.1</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 
@@ -18,4 +17,5 @@
     <applicationMonitor updateTrigger="mbean" />
 
     <jndiEntry jndiName="env/foo" value="${env.foo}" />
+
 </server>

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -22,6 +22,16 @@ The following features are required in the `server.xml` of the Liberty server.
 </featureManager>
 ```
 
+or
+
+```
+<!-- Enable features -->
+<featureManager>
+    <feature>restfulWS-3.0</feature>
+    <feature>restConnector-2.0</feature>
+</featureManager>
+```
+
 You will also need to enable security, one example would be:
 
 ```
@@ -32,28 +42,29 @@ You will also need to enable security, one example would be:
 
 You need to have those keys trusted by your client as well, otherwise you'll see SSL certificate trust errors, and you need to give permissions for the container adapter to write to the dropins directory:
 
-````
+```
 <!-- This section is needed to allow upload of files to the dropins directory,
 the remote container adapter relies on this configuration -->
 <remoteFileAccess>
     <writeDir>${server.config.dir}/dropins</writeDir>
 </remoteFileAccess>
-````
+```
 
 If you need a sample `server.xml`, please refer to the [one in our source repository](https://github.com/OpenLiberty/liberty-arquillian/blob/main/liberty-remote/src/test/resources/server.xml).
 
 ## Configuration
 
-Default Protocol: Servlet 5.0
+Default Protocol: Servlet 5.0 or REST 3.0 depending on configuration
 
 To enable Arquillian Liberty Remote in your project, add the following to your `pom.xml`:
+
 ```xml
 <dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha9</version>
+			<version>1.7.0.Alpha12</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -65,7 +76,7 @@ To enable Arquillian Liberty Remote in your project, add the following to your `
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-remote-jakarta</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0</version>
 		<scope>test</scope>
 	</dependency>
 	...
@@ -86,6 +97,7 @@ To enable Arquillian Liberty Remote in your project, add the following to your `
 | appDeployTimeout | Integer | 20 | Time in seconds to wait for the application deployment to complete and the application to start |
 | appUndeployTimeout | Integer | 2 | Time in seconds to wait for the application undeployment to complete |
 | outputToConsole | Boolean | true | When enabled output from the application server process will be emitted to stdout |
+| testProtocol | String | servlet | Aquillian protocol to contact the server to run a test (available: servlet or rest) |
 
 ## Examples
 
@@ -122,7 +134,7 @@ xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/a
 		<dependency>
 			<groupId>io.openliberty.arquillian</groupId>
 			<artifactId>arquillian-liberty-remote-jakarta</artifactId>
-			<version>2.0.0</version>
+			<version>2.1.0</version>
 		</dependency>
 	</dependencies>
 </profile>

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>arquillian-liberty-remote-jakarta</artifactId>
@@ -62,24 +62,36 @@
               <name>java.util.logging.config.file</name>
               <value>${loggingPropertiesFile}</value>
             </property>
-            <property>
-              <name>javax.net.ssl.trustStore</name>
-              <value>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/resources/security/key.jks</value>
-            </property>
           </systemProperties>
         </configuration>
         <executions>
           <execution>
-            <id>wlp-8554-test</id>
+            <id>wlp-remote-deployment-servlet-test</id>
             <goals>
               <goal>test</goal>
             </goals>
             <configuration>
               <skip>${skipTests}</skip>
-              <reportsDirectory>${project.build.directory}/surefire-reports/wlp-remote-deployment-test
+              <reportsDirectory>${project.build.directory}/surefire-reports/wlp-remote-deployment-servlet-test
               </reportsDirectory>
               <systemPropertyVariables>
                 <arquillian.launch>wlp-remote</arquillian.launch>
+                <javax.net.ssl.trustStore>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/resources/security/key.jks</javax.net.ssl.trustStore>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+          <execution>
+            <id>wlp-remote-deployment-rest-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <reportsDirectory>${project.build.directory}/surefire-reports/wlp-remote-deployment-rest-test
+              </reportsDirectory>
+              <systemPropertyVariables>
+                <arquillian.launch>wlp-rest-remote</arquillian.launch>
+                <javax.net.ssl.trustStore>${project.build.directory}/liberty/wlp/usr/servers/restServer/resources/security/key.jks</javax.net.ssl.trustStore>
               </systemPropertyVariables>
             </configuration>
           </execution>
@@ -106,6 +118,29 @@
           <execution>
             <id>stop-server</id>
             <phase>test</phase>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>start-rest-server</id>
+            <!-- Plugin execution needs to be bound to previous phase.
+                 Because Maven. See MNG-5799 and MNG-5987 -->
+            <phase>process-test-classes</phase>
+            <configuration>
+              <serverName>restServer</serverName>
+               <serverXmlFile>src/test/resources/restServer.xml</serverXmlFile>
+             </configuration>
+            <goals>
+              <goal>start</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop-rest-server</id>
+            <phase>test</phase>
+            <configuration>
+              <serverName>restServer</serverName>
+             </configuration>
             <goals>
               <goal>stop</goal>
             </goals>
@@ -149,6 +184,10 @@
     <dependency>
       <groupId>org.jboss.arquillian.container</groupId>
       <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.protocol</groupId>
+      <artifactId>arquillian-protocol-rest-jakarta</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.protocol</groupId>

--- a/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainer.java
+++ b/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * Copyright 2014, 2022 Red Hat Inc. and/or its affiliates and other contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +106,7 @@ public class WLPRemoteContainer implements DeployableContainer<WLPRemoteContaine
             log.entering(className, "getDefaultProtocol");
         }
 
-        String defaultProtocol = "Servlet 5.0";
+        String defaultProtocol = containerConfiguration.isServletTestProtocol() ? "Servlet 5.0" : "REST 3.0";
 
         if (log.isLoggable(Level.FINER)) {
             log.exiting(className, "getDefaultProtocol", defaultProtocol);
@@ -147,7 +147,9 @@ public class WLPRemoteContainer implements DeployableContainer<WLPRemoteContaine
         // Return metadata on how to contact the deployed application
         ProtocolMetaData metaData = new ProtocolMetaData();
         HTTPContext httpContext = new HTTPContext(containerConfiguration.getHostName(), containerConfiguration.getHttpPort());
-        httpContext.add(new Servlet("ArquillianServletRunnerEE9", deployName));
+        String servletName = containerConfiguration.isServletTestProtocol() ?
+                "ArquillianServletRunnerEE9" : "ArquillianRESTRunnerEE9";
+        httpContext.add(new Servlet(servletName, deployName));
         metaData.addContext(httpContext);
 
         if (log.isLoggable(Level.FINER)) {

--- a/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainerConfiguration.java
+++ b/liberty-remote/src/main/java/io/openliberty/arquillian/remote/WLPRemoteContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2014, Red Hat Middleware LLC, and other contributors
+ * Copyright 2012, 2022 Red Hat Middleware LLC, and other contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,7 @@ public class WLPRemoteContainerConfiguration implements ContainerConfiguration {
     private int httpPort = 9080;
     private int httpsPort = 9443;
     private boolean outputToConsole = true;
+    private String testProtocol = "servlet";
 
     @Override
     public void validate() throws ConfigurationException {
@@ -66,6 +67,9 @@ public class WLPRemoteContainerConfiguration implements ContainerConfiguration {
         if (httpsPort > 65535 || httpsPort < 0)
             throw new ConfigurationException("httpsPort provided is not valid: " + httpPort);
 
+        if (!"rest".equalsIgnoreCase(testProtocol) && !"servlet".equalsIgnoreCase(testProtocol)) {
+            throw new ConfigurationException("testProtocol must be set to rest or servlet");
+        }
     }
 
     public String getServerName() {
@@ -148,4 +152,15 @@ public class WLPRemoteContainerConfiguration implements ContainerConfiguration {
         this.httpsPort = httpsPort;
     }
 
+    public String getTestProtocol() {
+        return testProtocol;
+    }
+
+    public void setTestProtocol(String protocol) {
+        this.testProtocol = protocol;
+    }
+
+    public boolean isServletTestProtocol() {
+        return "servlet".equalsIgnoreCase(testProtocol);
+    }
 }

--- a/liberty-remote/src/test/resources/arquillian.xml
+++ b/liberty-remote/src/test/resources/arquillian.xml
@@ -18,4 +18,15 @@
 			<property name="httpsPort">9443</property>
 		</configuration>
 	</container>
+	<container qualifier="wlp-rest-remote">
+		<configuration>	
+			<property name="hostName">localhost</property>
+			<property name="serverName">restServer</property>
+			<property name="username">admin</property>
+			<property name="password">admin</property>
+			<property name="httpPort">9081</property>
+			<property name="httpsPort">9444</property>
+            <property name="testProtocol">rest</property>
+		</configuration>
+	</container>
 </arquillian>

--- a/liberty-remote/src/test/resources/restServer.xml
+++ b/liberty-remote/src/test/resources/restServer.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Sample server.xml configuration for use with WLP remote Arquillian container 
+	adapter -->
+<server description="new server">
+
+	<featureManager>
+		<feature>restfulWS-3.0</feature>
+		<feature>localConnector-1.0</feature>
+		<feature>cdi-3.0</feature>
+		<feature>restConnector-2.0</feature>
+	</featureManager>
+
+	<httpEndpoint httpPort="9081" httpsPort="9444"
+		id="defaultHttpEndpoint" host="*" />
+
+	<!-- userName and password should also be set in arquillian.xml to these 
+		values -->
+	<quickStartSecurity userName="admin" userPassword="admin" />
+
+	<!-- Enable the keystore -->
+	<keyStore id="defaultKeyStore" password="password" location="key.jks" type="JKS"/>
+
+	<applicationMonitor updateTrigger="mbean" />
+	<logging consoleLogLevel="INFO" />
+
+
+	<!-- This section is needed to allow upload of files to the dropins directory, 
+		the remote container adapter relies on this configuration -->
+	<remoteFileAccess>
+		<writeDir>${server.config.dir}/dropins</writeDir>
+	</remoteFileAccess>
+
+</server>

--- a/liberty-support-feature/JakartaEE9_README.md
+++ b/liberty-support-feature/JakartaEE9_README.md
@@ -19,7 +19,7 @@ Example:
   <dependency>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-liberty-support-jakarta</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
   </dependency>
 </dependencies>
 <plugin>
@@ -40,7 +40,7 @@ Example:
       <artifactItem>
         <groupId>io.openliberty.arquillian</groupId>
         <artifactId>arquillian-liberty-support-jakarta</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <type>zip</type>
         <classifier>feature</classifier>
         <overWrite>false</overWrite>
@@ -50,12 +50,12 @@ Example:
   </configuration>
 </plugin>
 ```
-Then add `<feature>usr:arquillian-support-jakarta-2.0</feature>` to the `<featureManager>` section of your `server.xml`.
+Then add `<feature>usr:arquillian-support-jakarta-2.1</feature>` to the `<featureManager>` section of your `server.xml`.
 ```
 <featureManager>
     <feature>pages-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-jakarta-2.0</feature>
+    <feature>usr:arquillian-support-jakarta-2.1</feature>
 </featureManager>
 ```
 
@@ -67,12 +67,12 @@ git clone git@github.com:OpenLiberty/liberty-arquillian.git
 mvn install
 ```
 2.  Extract the arquillian-liberty-support-jakarta-x.x.x-feature.zip into the `usr` directory of your Liberty runtime
-3. Add `<feature>usr:arquillian-support-jakarta-2.0</feature>` to the `<featureManager>` section of your `server.xml`
+3. Add `<feature>usr:arquillian-support-jakarta-2.1</feature>` to the `<featureManager>` section of your `server.xml`
 
 ```
 <featureManager>
     <feature>pages-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-jakarta-2.0</feature>
+    <feature>usr:arquillian-support-jakarta-2.1</feature>
 </featureManager>
 ```

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
+++ b/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
@@ -1,10 +1,10 @@
 IBM-Feature-Version: 2
-IBM-ShortName: arquillian-support-jakarta-2.0
+IBM-ShortName: arquillian-support-jakarta-2.1
 Subsystem-Content: arquillian-liberty-support-jakarta; version=${parsedVersion.osgiVersion},
  com.ibm.websphere.appserver.localConnector-1.0; type="osgi.subsystem.feature"
 Subsystem-Description: Jakarta Liberty Feature to support integration for the Arquillian Project
 Subsystem-ManifestVersion: 1
 Subsystem-Name: Arquillian Support Jakarta Feature
-Subsystem-SymbolicName: io.openliberty.arquillian.arquillian-support-jakarta-2.0; visibility:=public
+Subsystem-SymbolicName: io.openliberty.arquillian.arquillian-support-jakarta-2.1; visibility:=public
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: ${parsedVersion.osgiVersion}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <!-- Artifact Configuration -->
   <groupId>io.openliberty.arquillian</groupId>
   <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-  <version>2.0.3-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Arquillian Container Liberty Jakarta Parent</name>
   <description>Jakarta Liberty Container integrations for the Arquillian Project</description>
@@ -38,7 +38,7 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.7.0.Alpha10</version.arquillian_core>
+    <version.arquillian_core>1.7.0.Alpha12</version.arquillian_core>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>
 
     <!-- override from parent -->
@@ -102,7 +102,7 @@
       </activation>
       <properties>
         <runtime>ol</runtime>
-        <runtimeGroupId>io.openliberty</runtimeGroupId>
+        <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
         <runtimeVersion>${runtimeVersion}</runtimeVersion>
       </properties>
@@ -118,9 +118,9 @@
       </activation>
       <properties>
         <runtime>ol</runtime>
-        <runtimeGroupId>io.openliberty</runtimeGroupId>
+        <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>22.0.0.6</runtimeVersion>
+        <runtimeVersion>22.0.0.9-beta</runtimeVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
#### Short description of what this resolves:
Today liberty arquillian has a servlet dependency in order to run a test on the application server.  To test functions like CDI and RESTful Web Services that do not require servlet, this is not suitable since MicroProfile and now Core Profile in Jakarta EE 10 does not require the application server to expose servlet API and function in applications.  This PR provides a way to run a test on a server that does not have servlet enabled by using a RESTful Web Services resource instead. 

#### Changes proposed in this pull request:
- Use the new RESTful Web Services arquillian protocol so do not need to depend on servlet in an application server in order to run tests on the server.
- Add a testProtocol option to the remote and managed liberty container functions to be able to specify either rest or servlet to run.
- Run the tests a second time with the rest configuration instead of servlet.
- Update Jakarta EE 9 README information for the new functions.
- Update version from 2.0.x to 2.1.0

**Fixes**: #113
