### PR TITLE
bump annotation version for j17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [1.8, 11]
+        java: [1.8, 11, 17]
         runtime: [ol]
         runtime_version: [22.0.0.6]
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
           <groupId>jakarta.annotation</groupId>
           <artifactId>jakarta.annotation-api</artifactId>
-          <version>2.0.0</version>
+          <version>2.1.1</version>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
#### Short description of what this resolves:
Simply bump the 2-year-outdated Jakarta Annotation Api version for Java17

#### Changes proposed in this pull request:
jakarta.annotation-api bump from 2.0.0 -> 2.1.1

**Fixes**: #
For `arquillian-tests`
https://github.com/OpenLiberty/ci.maven/issues/1525#issuecomment-1170364558