### PR TITLE
Support running with wlp and ol beta images

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,12 +10,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 7
       matrix:
         os: [ubuntu-latest, windows-latest]
         java: [1.8, 11]
-        runtime: [ol]
-        runtime_version: [22.0.0.9-beta]
+        runtime: [ol, olbeta, wlp]
+        runtime_version: [22.0.0.8, 22.0.0.9-beta]
+        exclude:
+        - runtime: olbeta
+          runtime_version: 22.0.0.8
+        - runtime: ol
+          runtime_version: 22.0.0.9-beta
+        - runtime: wlp
+          runtime_version: 22.0.0.9-beta
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Arquillian](http://arquillian.org/) is a testing framework to develop automated functional, integration and acceptance tests for your Java applications. Arquillian container adapters allow Arquillian to bind to and manage the lifecycle of a runtime. There are two types of Arquillian container adapters for Liberty: [Liberty Managed](#Arquillian-Liberty-Managed-Container) and [Liberty Remote](#Arquillian-Liberty-Remote-Container).
 
-### Arquillian Liberty Mangaged Container
+### Arquillian Liberty Managed Container
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM). For an introduction to testing microservices with the Arquillian Liberty Managed container and [Open Liberty](https://openliberty.io/), check out the [this guide](https://openliberty.io/guides/arquillian-managed.html).
 
@@ -24,11 +24,11 @@ To run tests, you will need to specify the following parameters:
 
 | Parameter        | Description |
 | ---------------- | ----------- |
-| runtime          | The runtime to use. Specify `ol` for Open Liberty and `wlp` for WebSphere Liberty. |
+| runtime          | The runtime to use. Specify `ol` for Open Liberty, `olbeta` for Open Liberty beta, and `wlp` for WebSphere Liberty. |
 | runtimeVersion   | Version of the specified runtime to use. |
 
-For example, to run tests on version 20.0.0.11 of the Open Liberty runtime, use the following command:
+For example, to run tests on version 22.0.0.6 of the Open Liberty runtime, use the following command:
 
 ```
-mvn verify -Druntime=ol -DruntimeVersion=20.0.0.11
+mvn verify -Druntime=ol -DruntimeVersion=22.0.0.6
 ```

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -58,9 +58,6 @@
       <activation>
           <jdk>[11,)</jdk>
       </activation>
-      <properties>
-        <skipEE10Tests>false</skipEE10Tests>
-      </properties>
       <dependencies>
         <dependency>
           <groupId>jakarta.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,7 @@
 
   <!-- Profiles for WLP vs OL -->
   <profiles>
-    <!-- Commented out as there is not currently support for Jakarta EE 9 in WL-->
-    <!-- <profile>
+    <profile>
       <id>wlp-its</id>
       <activation>
           <property>
@@ -88,10 +87,11 @@
       <properties>
           <runtime>wlp</runtime>
           <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
-          <runtimeArtifactId>wlp-javaee7</runtimeArtifactId>
+          <runtimeArtifactId>wlp-jakartaee9</runtimeArtifactId>
           <runtimeVersion>${runtimeVersion}</runtimeVersion>
+          <skipEE10Tests>true</skipEE10Tests>
       </properties>
-    </profile> -->
+    </profile>
     <profile>
       <id>ol-its</id>
       <activation>
@@ -102,6 +102,22 @@
       </activation>
       <properties>
         <runtime>ol</runtime>
+        <runtimeGroupId>io.openliberty</runtimeGroupId>
+        <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
+        <runtimeVersion>${runtimeVersion}</runtimeVersion>
+        <skipEE10Tests>true</skipEE10Tests>
+      </properties>
+    </profile>
+    <profile>
+      <id>olbeta-its</id>
+      <activation>
+        <property>
+          <name>runtime</name>
+          <value>olbeta</value>
+        </property>
+      </activation>
+      <properties>
+        <runtime>olbeta</runtime>
         <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
         <runtimeVersion>${runtimeVersion}</runtimeVersion>
@@ -112,12 +128,12 @@
       <activation>
         <property>
           <name>runtime</name>
-          <value>ol</value>
+          <value>olbeta</value>
         </property>
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <runtime>ol</runtime>
+        <runtime>olbeta</runtime>
         <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
         <runtimeVersion>22.0.0.9-beta</runtimeVersion>


### PR DESCRIPTION
#### Short description of what this resolves:
WebSphere Liberty testing was removed since at the time WebSphere Liberty did not support Jakarta EE 9.  Now that WebSphere Liberty supports Jakarta EE 9, this adds this testing back in.

#### Changes proposed in this pull request:

- Add back support for WebSphere Liberty testing since it support Jakarta EE 9 now.
- Add a new profile for ol beta so you can run either Open Liberty generally available release or a beta release.
- Update the workflows to test Open Liberty, Open Liberty beta and WebSphere Liberty.  When not running beta the EE10 tests are not run since they are in beta.

**Fixes**: #113
