### PR TITLE
Only allow web.xml and web-fragment.xml

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -733,7 +733,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
             }
             // if the current resource is a web.xml / web-fragment.xml file read the servlet
             // names from the xml
-            if (key.get().endsWith("web.xml") || key.get().endsWith("web-fragment.xml")) {
+            if (key.get().endsWith("/web.xml") || key.get().endsWith("/web-fragment.xml")) {
                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
                DocumentBuilder builder = factory.newDocumentBuilder();
                Document doc = builder.parse(node.getAsset().openStream());


### PR DESCRIPTION
#### Short description of what this resolves:

Files that end with web.xml or web-fragment.xml cause errors when using the liberty arquillian plugin.  Only files that have the exact name of web.xml and web-fragment.xml should be treated as web XML descriptors.  This change was identified while doing TCK testing for Jakarta EE 10 where some applications have a glassfish-web.xml file in them.

#### Changes proposed in this pull request:

- Only accept for files that have the exact name of web.xml and web-fragment.xml to be treated as web XML descriptors.

**Fixes**: #113
