### PR TITLE
Upgrade to liberty arquillian 1.7.0.Alpha13

### DIFF
--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -56,7 +56,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha12</version>
+			<version>1.7.0.Alpha13</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -64,7 +64,7 @@ To enable Arquillian Liberty Remote in your project, add the following to your `
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha12</version>
+			<version>1.7.0.Alpha13</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.7.0.Alpha12</version.arquillian_core>
+    <version.arquillian_core>1.7.0.Alpha13</version.arquillian_core>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>
 
     <!-- override from parent -->


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes a problem when the application that is augmented with the arquillian plugin has an ApplicationPath of /.

#### Changes proposed in this pull request:
- Move to Arqillian 1.7.0.Alpha13 with the fix for the issue.

**Fixes**: #113
