### PR TITLE
Add Java 17 and bump dependencies and Liberty versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,22 +13,25 @@ jobs:
       max-parallel: 7
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [1.8, 11]
+        java: [8, 11, 17]
         runtime: [ol, olbeta, wlp]
-        runtime_version: [22.0.0.8, 22.0.0.9-beta]
+        runtime_version: [22.0.0.10, 22.0.0.11-beta]
         exclude:
         - runtime: olbeta
-          runtime_version: 22.0.0.8
+          runtime_version: 22.0.0.10
         - runtime: ol
-          runtime_version: 22.0.0.9-beta
+          runtime_version: 22.0.0.11-beta
         - runtime: wlp
-          runtime_version: 22.0.0.9-beta
+          runtime_version: 22.0.0.11-beta
+        - java: 8
+          runtime_version: 22.0.0.11-beta
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: mvn verify -Druntime="${{ matrix.runtime }}" -DruntimeVersion="${{ matrix.runtime_version }}"

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -75,7 +75,7 @@
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.3.4</version>
+        <version>3.7.1</version>
         <configuration>
           <skip>${skipTests}</skip>
           <serverName>defaultServer</serverName>
@@ -381,7 +381,7 @@
         <dependency>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
-          <version>2.8.0</version>
+          <version>2.11.0</version>
         </dependency>
 
         <!-- Jakarta EE Spec APIs -->

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -100,7 +100,7 @@
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.3.4</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>start-server</id>

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.2</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <!-- Versioning -->
     <version.arquillian_core>1.7.0.Alpha13</version.arquillian_core>
-    <version.surefire.plugin>2.22.2</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
 
     <!-- override from parent -->
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -136,7 +136,7 @@
         <runtime>olbeta</runtime>
         <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>22.0.0.9-beta</runtimeVersion>
+        <runtimeVersion>22.0.0.11-beta</runtimeVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
#### Short description of what this resolves:
Add Java 17 testing

#### Changes proposed in this pull request:

- Add Java 17 to maven.yml
- Test more recent versions of Liberty
- Bump some dependencies to later versions
