### PR TITLE
Fix REST protocol when no servlets are defined and switch to newer Arquillian and liberty levels

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,17 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         java: [8, 11, 17]
-        runtime: [ol, olbeta, wlp]
-        runtime_version: [22.0.0.10, 22.0.0.11-beta]
+        runtime: [ol, wlp-ee9, wlp-ee10]
+        runtime_version: [23.0.0.3]
         exclude:
-        - runtime: olbeta
-          runtime_version: 22.0.0.10
-        - runtime: ol
-          runtime_version: 22.0.0.11-beta
-        - runtime: wlp
-          runtime_version: 22.0.0.11-beta
         - java: 8
-          runtime_version: 22.0.0.11-beta
+          runtime: wlp-ee10
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM). For an introduction to testing microservices with the Arquillian Liberty Managed container and [Open Liberty](https://openliberty.io/), check out the [this guide](https://openliberty.io/guides/arquillian-managed.html).
 
-**Jakarta EE 9:** for Arquillian Liberty Managed container documentation with Jakarta EE 9, click [here](liberty-managed/JakartaEE9_README.md).
+**Jakarta EE 9 and 10:** for Arquillian Liberty Managed container documentation with Jakarta EE 9 and EE 10, click [here](liberty-managed/JakartaEE9_README.md).
 
 **Java EE 8 or below:** for Arquillian Liberty Managed container documentation with Java EE 8 or below, click [here](liberty-managed/README.md).
 
@@ -14,7 +14,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can connect and run against a remote (different JVM, different machine) Liberty server and run tests on it over a remote protocol (effectively in a different JVM).
 
-**Jakarta EE 9:** for Arquillian Liberty Remote container documentation with Jakarta EE 9, click [here](liberty-remote/JakartaEE9_README.md).
+**Jakarta EE 9 and 10:** for Arquillian Liberty Remote container documentation with Jakarta EE 9 and EE 10, click [here](liberty-remote/JakartaEE9_README.md).
 
 **Java EE 8 or below:** for Arquillian Liberty Remote container documentation with Java EE 8 or below, click [here](liberty-remote/README.md).
 
@@ -24,7 +24,7 @@ To run tests, you will need to specify the following parameters:
 
 | Parameter        | Description |
 | ---------------- | ----------- |
-| runtime          | The runtime to use. Specify `ol` for Open Liberty, `olbeta` for Open Liberty beta, and `wlp` for WebSphere Liberty. |
+| runtime          | The runtime to use. Specify `ol` for Open Liberty, `olbeta` for Open Liberty beta, and `wlp-ee9` or `wlp-ee10` for WebSphere Liberty. |
 | runtimeVersion   | Version of the specified runtime to use. |
 
 For example, to run tests on version 22.0.0.6 of the Open Liberty runtime, use the following command:
@@ -32,3 +32,5 @@ For example, to run tests on version 22.0.0.6 of the Open Liberty runtime, use t
 ```
 mvn verify -Druntime=ol -DruntimeVersion=22.0.0.6
 ```
+
+EE 9 archive images are no longer published for WebSphere Liberty so runtimeVersion is ignored for `wlp-ee9` and 23.0.0.2 is used which is the last version of the wlp-jakartaee9 archive that was published.

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -1,4 +1,4 @@
-# Arquillian Liberty Managed with Jakarta EE 9
+# Arquillian Liberty Managed with Jakarta EE 9 and 10
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM). 
 
@@ -6,7 +6,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 **Prerequisite Version**
 
-This `DeployableContainer` has been tested with the latest beta release of Open Liberty. Requires Jakarta EE 9.
+This `DeployableContainer` has been tested with the latest release of Open Liberty. Requires Jakarta EE 9 or 10.
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
@@ -56,7 +56,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha14</version>
+			<version>1.7.0.Final</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>

--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -8,7 +8,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 This `DeployableContainer` has been tested with the latest two releases of Open Liberty and WebSphere Liberty. Requires Java EE 8 or below.
 
-For Jakarta EE 9 projects, check out the documentation [here](JakartaEE9_README.md).
+For Jakarta EE 9 and EE 10 projects, check out the documentation [here](JakartaEE9_README.md).
 
 **Prerequisite Configuration**
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -82,7 +82,7 @@
           <assemblyArtifact>
             <groupId>${runtimeGroupId}</groupId>
             <artifactId>${runtimeArtifactId}</artifactId>
-            <version>${runtimeVersion}</version>
+            <version>${libertyVersion}</version>
             <type>zip</type>
           </assemblyArtifact>
           <serverEnv>src/test/resources/server.env</serverEnv>
@@ -211,6 +211,7 @@
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
+                  <skip>${skipEE9Tests}</skip>
                   <reportsDirectory>${project.build.directory}/surefire-reports/wlp-dropins-deployment-servlet-test
                   </reportsDirectory>
                   <systemPropertyVariables>
@@ -230,6 +231,7 @@
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
+                  <skip>${skipEE9Tests}</skip>
                   <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-deployment-servlet-test</reportsDirectory>
                   <systemPropertyVariables>
                     <arquillian.launch>wlp-xml-deployment-servlet</arquillian.launch>
@@ -248,6 +250,7 @@
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
+                  <skip>${skipEE9Tests}</skip>
                   <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-servlet-test</reportsDirectory>
                   <systemPropertyVariables>
                     <arquillian.launch>wlp-xml-management-deployment-servlet</arquillian.launch>
@@ -263,6 +266,7 @@
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
+                  <skip>${skipEE9Tests}</skip>
                   <reportsDirectory>${project.build.directory}/surefire-reports/wlp-dropins-deployment-rest-test
                   </reportsDirectory>
                   <systemPropertyVariables>
@@ -282,6 +286,7 @@
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
+                  <skip>${skipEE9Tests}</skip>
                   <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-deployment-rest-test</reportsDirectory>
                   <systemPropertyVariables>
                     <arquillian.launch>wlp-xml-deployment-rest</arquillian.launch>
@@ -300,6 +305,7 @@
                 </goals>
                 <configuration>
                   <skip>${skipTests}</skip>
+                  <skip>${skipEE9Tests}</skip>
                   <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-rest-test</reportsDirectory>
                   <systemPropertyVariables>
                     <arquillian.launch>wlp-xml-management-deployment-rest</arquillian.launch>

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2012, 2023 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -653,8 +653,8 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
          // If we didn't find any servlets and this is a testable archive it ought to
          // contain the arquillian test servlet, which is all that most tests need to
          // work
-         if (containerConfiguration.isServletTestProtocol() && servletNames.isEmpty() && Testable.isArchiveToTest(webModule.archive)) {
-            servletNames.add(ARQUILLIAN_SERVLET_NAME);
+         if (servletNames.isEmpty() && Testable.isArchiveToTest(webModule.archive)) {
+            servletNames.add(containerConfiguration.isServletTestProtocol() ? ARQUILLIAN_SERVLET_NAME : ARQUILLIAN_REST_NAME);
          }
          return servletNames;
       } catch (Exception e) {

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -1,4 +1,4 @@
-# Arquillian Liberty Remote with Jakarta EE 9
+# Arquillian Liberty Remote with Jakarta EE 9 and 10
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can connect and run against a remote (different JVM, different machine) Liberty server andrun tests on it over a remote protocol (effectively in a different JVM).
 
@@ -6,7 +6,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 **Prerequisite Version**
 
-This `DeployableContainer` has been tested with the latest beta release of Open Liberty. Requires Jakarta EE 9.
+This `DeployableContainer` has been tested with the latest release of Open Liberty. Requires Jakarta EE 9 or EE 10.
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
@@ -64,7 +64,7 @@ To enable Arquillian Liberty Remote in your project, add the following to your `
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Alpha13</version>
+			<version>1.7.0.Final</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>

--- a/liberty-remote/README.md
+++ b/liberty-remote/README.md
@@ -8,7 +8,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 This `DeployableContainer` has been tested with the latest two releases of Open Liberty and WebSphere Liberty. Requires Java EE 8 or below.
 
-For Jakarta EE 9 projects, check out the documentation [here](JakartaEE9_README.md).
+For Jakarta EE 9 and 10 projects, check out the documentation [here](JakartaEE9_README.md).
 
 **Prerequisite Configuration**
 

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -72,6 +72,7 @@
             </goals>
             <configuration>
               <skip>${skipTests}</skip>
+              <skip>${skipEE9Tests}</skip>
               <reportsDirectory>${project.build.directory}/surefire-reports/wlp-remote-deployment-servlet-test
               </reportsDirectory>
               <systemPropertyVariables>
@@ -87,6 +88,7 @@
             </goals>
             <configuration>
               <skip>${skipTests}</skip>
+              <skip>${skipEE9Tests}</skip>
               <reportsDirectory>${project.build.directory}/surefire-reports/wlp-remote-deployment-rest-test
               </reportsDirectory>
               <systemPropertyVariables>
@@ -152,7 +154,7 @@
           <assemblyArtifact>
             <groupId>${runtimeGroupId}</groupId>
             <artifactId>${runtimeArtifactId}</artifactId>
-            <version>${runtimeVersion}</version>
+            <version>${libertyVersion}</version>
             <type>zip</type>
           </assemblyArtifact>
         </configuration>

--- a/liberty-support-feature/JakartaEE9_README.md
+++ b/liberty-support-feature/JakartaEE9_README.md
@@ -1,4 +1,4 @@
-# Arquillian support Liberty user feature with Jakarta EE 9
+# Arquillian support Liberty user feature with Jakarta EE 9 and 10
 
 A Liberty user feature which allows deployment exceptions to be reported more reliably when using the Liberty Managed Jakarta container.
 
@@ -6,7 +6,7 @@ The Arquillian support feature adds an additional http endpoint which the Arquil
 
 It is only for supporting the running of Arquillian tests and must not be installed on a production system.
 
-Requires Jakarta EE 9. For Java EE 8 projects and below, check out the documentation [here](README.md).
+Requires Jakarta EE 9 or 10. For Java EE 8 projects and below, check out the documentation [here](README.md).
 
 ## Configuring with a Maven project
 

--- a/liberty-support-feature/README.md
+++ b/liberty-support-feature/README.md
@@ -6,7 +6,7 @@ The Arquillian support feature adds an additional http endpoint which the Arquil
 
 It is only for supporting the running of Arquillian tests and must not be installed on a production system.
 
-Requires Java EE 8 or below. For Jakarta EE 9 projects, check out the documentation [here](JakartaEE9_README.md).
+Requires Java EE 8 or below. For Jakarta EE 9 and 10 projects, check out the documentation [here](JakartaEE9_README.md).
 
 ## Configuring with a Maven project
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.7.0.Alpha14</version.arquillian_core>
+    <version.arquillian_core>1.7.0.Final</version.arquillian_core>
     <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
 
     <!-- override from parent -->
@@ -77,19 +77,35 @@
   <!-- Profiles for WLP vs OL -->
   <profiles>
     <profile>
-      <id>wlp-its</id>
+      <id>wlp-ee9-its</id>
       <activation>
           <property>
             <name>runtime</name>
-            <value>wlp</value>
+            <value>wlp-ee9</value>
           </property>
       </activation>
       <properties>
-          <runtime>wlp</runtime>
+          <runtime>wlp-ee9</runtime>
           <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
           <runtimeArtifactId>wlp-jakartaee9</runtimeArtifactId>
-          <runtimeVersion>${runtimeVersion}</runtimeVersion>
+          <libertyVersion>23.0.0.2</libertyVersion>
           <skipEE10Tests>true</skipEE10Tests>
+      </properties>
+    </profile>
+    <profile>
+      <id>wlp-ee10-its</id>
+      <activation>
+          <property>
+            <name>runtime</name>
+            <value>wlp-ee10</value>
+          </property>
+      </activation>
+      <properties>
+          <runtime>wlp-ee10</runtime>
+          <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
+          <runtimeArtifactId>wlp-jakartaee10</runtimeArtifactId>
+          <libertyVersion>${runtimeVersion}</libertyVersion>
+          <skipEE9Tests>true</skipEE9Tests>
       </properties>
     </profile>
     <profile>
@@ -104,8 +120,7 @@
         <runtime>ol</runtime>
         <runtimeGroupId>io.openliberty</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>${runtimeVersion}</runtimeVersion>
-        <skipEE10Tests>true</skipEE10Tests>
+        <libertyVersion>${runtimeVersion}</libertyVersion>
       </properties>
     </profile>
     <profile>
@@ -120,7 +135,7 @@
         <runtime>olbeta</runtime>
         <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>${runtimeVersion}</runtimeVersion>
+        <libertyVersion>${runtimeVersion}</libertyVersion>
       </properties>
     </profile>
     <profile>
@@ -128,15 +143,15 @@
       <activation>
         <property>
           <name>runtime</name>
-          <value>olbeta</value>
+          <value>ol</value>
         </property>
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <runtime>olbeta</runtime>
-        <runtimeGroupId>io.openliberty.beta</runtimeGroupId>
+        <runtime>ol</runtime>
+        <runtimeGroupId>io.openliberty</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <runtimeVersion>22.0.0.11-beta</runtimeVersion>
+        <libertyVersion>23.0.0.3</libertyVersion>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes scenarios where a WAR is a test archive and doesn't have servlets and you are using the REST protocol.  This problem was identified with using the new 1.7.0.Final Arquillian release with the CDI TCK.

#### Changes proposed in this pull request:

- When adding REST protocol, the logic was updated to only add the servlet if using the servlet protocol.  This update adds the REST "servlet" as well when there are no servlets.
- Switch to Arquillian 1.7.0.Final and update documentation to point to 1.7.0.Final
- Switch to using GA level of OL and WL now that EE 10 function is now available in the product and not only in beta
- Update to test both EE 9 and EE 10 with WebSphere Liberty.

**Fixes**: #113
