### PR TITLE
Set explicit beans.xml scanning mode

### DIFF
--- a/liberty-managed/src/resources/beans.xml
+++ b/liberty-managed/src/resources/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
+bean-discovery-mode="all"
+       version="1.1"> 
+</beans>

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPInjectionTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPInjectionTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2013-2023, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +14,14 @@
  */
 package io.openliberty.arquillian.managed;
 
+import java.io.File;
+
 import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,7 +34,7 @@ public class WLPInjectionTestCase
    public static JavaArchive createDeployment() {
        JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
            .addClass(Greeter.class)
-           .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+           .addAsManifestResource(new FileAsset(new File("src/resources/beans.xml")), "beans.xml");
        return jar;
    }
    

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPIntegrationClientTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPIntegrationClientTestCase.java
@@ -15,6 +15,7 @@
 package io.openliberty.arquillian.managed;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -23,7 +24,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -45,7 +46,7 @@ public class WLPIntegrationClientTestCase
                               .addClass(HelloServlet.class))
             .addAsModule(ShrinkWrap.create(JavaArchive.class, "test.jar")
                               .addClass(WLPIntegrationClientTestCase.class)
-                              .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+                              .addAsManifestResource(new FileAsset(new File("src/resources/beans.xml")), "beans.xml"));
    }
    
    @Test

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/WLPResourceTestCase.java
@@ -1,9 +1,11 @@
 package io.openliberty.arquillian.managed;
 
+import java.io.File;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,7 +18,7 @@ public class WLPResourceTestCase {
     @Deployment
     public static JavaArchive createDeployment() {
         return ShrinkWrap.create(JavaArchive.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(new FileAsset(new File("src/resources/beans.xml")), "beans.xml");
     }
 
     @Resource(lookup = "env/foo")

--- a/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/WLPDeploymentExceptionTest.java
+++ b/liberty-managed/src/test/java/io/openliberty/arquillian/managed/needssupportfeature/deploymentfailure/WLPDeploymentExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2019-2023, IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,8 @@ package io.openliberty.arquillian.managed.needssupportfeature.deploymentfailure;
 
 import static org.junit.Assert.fail;
 
+import java.io.File;
+
 import jakarta.enterprise.inject.spi.Extension;
 
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -23,7 +25,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +41,7 @@ public class WLPDeploymentExceptionTest {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
                                    .addPackage(WLPDeploymentExceptionTest.class.getPackage())
                                    .addAsServiceProvider(Extension.class, StartupFailureExtension.class)
-                                   .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                                   .addAsWebInfResource(new FileAsset(new File("src/resources/beans.xml")), "beans.xml");
 
         return war;
     }

--- a/liberty-remote/src/resources/beans.xml
+++ b/liberty-remote/src/resources/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" 
+bean-discovery-mode="all"
+       version="1.1"> 
+</beans>

--- a/liberty-remote/src/test/java/io/openliberty/arquillian/remote/WLPInjectionTestCase.java
+++ b/liberty-remote/src/test/java/io/openliberty/arquillian/remote/WLPInjectionTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2013-2023, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +14,14 @@
  */
 package io.openliberty.arquillian.remote;
 
+import java.io.File;
+
 import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +32,7 @@ public class WLPInjectionTestCase {
     @Deployment
     public static JavaArchive createDeployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class).addClass(Greeter.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsManifestResource(new FileAsset(new File("src/resources/beans.xml")), "beans.xml");
         return jar;
     }
 

--- a/liberty-remote/src/test/java/io/openliberty/arquillian/remote/WLPIntegrationClientTestCase.java
+++ b/liberty-remote/src/test/java/io/openliberty/arquillian/remote/WLPIntegrationClientTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2012, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2010-2023, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 package io.openliberty.arquillian.remote;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 
@@ -22,7 +23,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -42,7 +43,7 @@ public class WLPIntegrationClientTestCase {
                 .addAsModule(ShrinkWrap.create(WebArchive.class, "test.war").addClass(HelloServlet.class))
                 .addAsModule(
                         ShrinkWrap.create(JavaArchive.class, "test.jar").addClass(WLPIntegrationClientTestCase.class)
-                                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"));
+                                .addAsManifestResource(new FileAsset(new File("src/resources/beans.xml")), "beans.xml"));
     }
 
     @Test


### PR DESCRIPTION
Setting an explicit scanning mode will make behaviour consistent across all versions of CDI.


#### Short description of what this resolves: The CDI 4.0 spec introduces a breaking change: An empty beans.xml fie is now treated as scanning mode annotated instead of mode all. This causes a problem because this plugin needs scanning mode all.


#### Changes proposed in this pull request: Replace every empty beans.xml file with one that explicitly declares a scanning mode of all

**Fixes**: # 134 (though other fixes may be required to fully resolve the issue)
