### PR TITLE
Bump commons-io version and Liberty version used for testing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java: [8, 11, 17]
         runtime: [ol, wlp-ee9, wlp-ee10]
-        runtime_version: [23.0.0.3]
+        runtime_version: [24.0.0.9]
         exclude:
         - java: 8
           runtime: wlp-ee10

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -387,7 +387,7 @@
         <dependency>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
-          <version>2.11.0</version>
+          <version>2.14.0</version>
         </dependency>
 
         <!-- Jakarta EE Spec APIs -->


### PR DESCRIPTION
Supersedes #138 
