### PR TITLE
Update dependencies for Jakarta EE 11 TCK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,12 +13,9 @@ jobs:
       max-parallel: 7
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17]
+        java: [11, 17, 21]
         runtime: [ol, wlp-ee9, wlp-ee10]
         runtime_version: [24.0.0.9]
-        exclude:
-        - java: 8
-          runtime: wlp-ee10
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM). For an introduction to testing microservices with the Arquillian Liberty Managed container and [Open Liberty](https://openliberty.io/), check out the [this guide](https://openliberty.io/guides/arquillian-managed.html).
 
-**Jakarta EE 9 and 10:** for Arquillian Liberty Managed container documentation with Jakarta EE 9 and EE 10, click [here](liberty-managed/JakartaEE9_README.md).
+**Jakarta EE 9, 10 and 11:** for Arquillian Liberty Managed container documentation with Jakarta EE 9, 10 and 11, click [here](liberty-managed/JakartaEE9_README.md).
 
 **Java EE 8 or below:** for Arquillian Liberty Managed container documentation with Java EE 8 or below, click [here](liberty-managed/README.md).
 
@@ -14,7 +14,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can connect and run against a remote (different JVM, different machine) Liberty server and run tests on it over a remote protocol (effectively in a different JVM).
 
-**Jakarta EE 9 and 10:** for Arquillian Liberty Remote container documentation with Jakarta EE 9 and EE 10, click [here](liberty-remote/JakartaEE9_README.md).
+**Jakarta EE 9, 10 and 11:** for Arquillian Liberty Remote container documentation with Jakarta EE 9, 10 and 11, click [here](liberty-remote/JakartaEE9_README.md).
 
 **Java EE 8 or below:** for Arquillian Liberty Remote container documentation with Java EE 8 or below, click [here](liberty-remote/README.md).
 

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -1,4 +1,4 @@
-# Arquillian Liberty Managed with Jakarta EE 9 and 10
+# Arquillian Liberty Managed with Jakarta EE 9, 10 and 11
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can start and stop a local Liberty process and run tests on it over a remote protocol (effectively in a different JVM). 
 
@@ -6,7 +6,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 **Prerequisite Version**
 
-This `DeployableContainer` has been tested with the latest release of Open Liberty. Requires Jakarta EE 9 or 10.
+This `DeployableContainer` has been tested with the latest release of Open Liberty. Requires Jakarta EE 9, 10 or 11.
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
@@ -19,7 +19,7 @@ The following features are required in the `server.xml` of the Liberty server.
 <featureManager>
     <feature>pages-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-jakarta-2.1</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
+    <feature>usr:arquillian-support-jakarta-3.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
 </featureManager>
 ```
 
@@ -30,11 +30,11 @@ or
 <featureManager>
     <feature>restfulWS-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-jakarta-2.1</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
+    <feature>usr:arquillian-support-jakarta-3.0</feature> <!-- Optional, needed for reliable reporting of correct DeploymentExceptions -->
 </featureManager>
 ```
 
-Read more about configuring the `arquillian-support-jakarta-2.1` feature [here](../liberty-support-feature/JakartaEE9_README.md).
+Read more about configuring the `arquillian-support-jakarta-3.0` feature [here](../liberty-support-feature/JakartaEE9_README.md).
 
 You will also need to enable the `applicationMonitor` MBean support in your `server.xml`:
 
@@ -56,7 +56,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Final</version>
+			<version>1.9.1.Final</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -68,7 +68,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-managed-jakarta</artifactId>
-		<version>2.1.3</version>
+		<version>3.0.0</version>
 		<scope>test</scope>
 	</dependency>
 	...

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -10,6 +10,8 @@ This `DeployableContainer` has been tested with the latest release of Open Liber
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
+For Jakarta EE 9 projects using Java SE 8, you will need to use the 2.x versions of the Liberty Arquillian plugin.
+
 **Prerequisite Configuration**
 
 The following features are required in the `server.xml` of the Liberty server.

--- a/liberty-managed/README.md
+++ b/liberty-managed/README.md
@@ -8,7 +8,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 This `DeployableContainer` has been tested with the latest two releases of Open Liberty and WebSphere Liberty. Requires Java EE 8 or below.
 
-For Jakarta EE 9 and EE 10 projects, check out the documentation [here](JakartaEE9_README.md).
+For Jakarta EE 9, 10 and 11 projects, check out the documentation [here](JakartaEE9_README.md).
 
 **Prerequisite Configuration**
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -193,12 +193,12 @@
             <version>${version.surefire.plugin}</version>
             <configuration>
               <skip>true</skip>
-              <systemProperties>
+              <systemPropertyVariables>
                 <property>
                   <name>java.util.logging.config.file</name>
                   <value>${loggingPropertiesFile}</value>
                 </property>
-              </systemProperties>
+              </systemPropertyVariables>
               <argLine>-Dproject.build.directory=${project.build.directory}</argLine>
               <trimStackTrace>false</trimStackTrace>
             </configuration>

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -10,6 +10,8 @@ This `DeployableContainer` has been tested with the latest release of Open Liber
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
+For Jakarta EE 9 projects using Java SE 8, you will need to use the 2.x versions of the Liberty Arquillian plugin.
+
 **Prerequisite Configuration**
 
 The following features are required in the `server.xml` of the Liberty server.

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -1,4 +1,4 @@
-# Arquillian Liberty Remote with Jakarta EE 9 and 10
+# Arquillian Liberty Remote with Jakarta EE 9, 10 and 11
 
 An Arquillian container adapter (`DeployableContainer` implementation) that can connect and run against a remote (different JVM, different machine) Liberty server andrun tests on it over a remote protocol (effectively in a different JVM).
 
@@ -6,7 +6,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 **Prerequisite Version**
 
-This `DeployableContainer` has been tested with the latest release of Open Liberty. Requires Jakarta EE 9 or EE 10.
+This `DeployableContainer` has been tested with the latest release of Open Liberty. Requires Jakarta EE 9, 10 or 11
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
@@ -64,7 +64,7 @@ To enable Arquillian Liberty Remote in your project, add the following to your `
 		<dependency>
 			<groupId>org.jboss.arquillian</groupId>
 			<artifactId>arquillian-bom</artifactId>
-			<version>1.7.0.Final</version>
+			<version>1.9.1.Final</version>
 			<scope>import</scope>
 			<type>pom</type>
 		</dependency>
@@ -76,7 +76,7 @@ To enable Arquillian Liberty Remote in your project, add the following to your `
 	<dependency>
 		<groupId>io.openliberty.arquillian</groupId>
 		<artifactId>arquillian-liberty-remote-jakarta</artifactId>
-		<version>2.1.3</version>
+		<version>3.0.0</version>
 		<scope>test</scope>
 	</dependency>
 	...
@@ -134,7 +134,7 @@ xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/a
 		<dependency>
 			<groupId>io.openliberty.arquillian</groupId>
 			<artifactId>arquillian-liberty-remote-jakarta</artifactId>
-			<version>2.1.3</version>
+			<version>3.0.0</version>
 		</dependency>
 	</dependencies>
 </profile>

--- a/liberty-remote/README.md
+++ b/liberty-remote/README.md
@@ -8,7 +8,7 @@ An Arquillian container adapter (`DeployableContainer` implementation) that can 
 
 This `DeployableContainer` has been tested with the latest two releases of Open Liberty and WebSphere Liberty. Requires Java EE 8 or below.
 
-For Jakarta EE 9 and 10 projects, check out the documentation [here](JakartaEE9_README.md).
+For Jakarta EE 9, 10 and 11 projects, check out the documentation [here](JakartaEE9_README.md).
 
 **Prerequisite Configuration**
 

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>arquillian-liberty-remote-jakarta</artifactId>

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -57,12 +57,12 @@
         <version>${version.surefire.plugin}</version>
         <configuration>
           <skip>true</skip>
-          <systemProperties>
+          <systemPropertyVariables>
             <property>
               <name>java.util.logging.config.file</name>
               <value>${loggingPropertiesFile}</value>
             </property>
-          </systemProperties>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>

--- a/liberty-support-feature/JakartaEE9_README.md
+++ b/liberty-support-feature/JakartaEE9_README.md
@@ -1,4 +1,4 @@
-# Arquillian support Liberty user feature with Jakarta EE 9 and 10
+# Arquillian support Liberty user feature with Jakarta EE 9, 10 and 11
 
 A Liberty user feature which allows deployment exceptions to be reported more reliably when using the Liberty Managed Jakarta container.
 
@@ -6,7 +6,7 @@ The Arquillian support feature adds an additional http endpoint which the Arquil
 
 It is only for supporting the running of Arquillian tests and must not be installed on a production system.
 
-Requires Jakarta EE 9 or 10. For Java EE 8 projects and below, check out the documentation [here](README.md).
+Requires Jakarta EE 9, 10 or 11. For Java EE 8 projects and below, check out the documentation [here](README.md).
 
 ## Configuring with a Maven project
 
@@ -19,7 +19,7 @@ Example:
   <dependency>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-liberty-support-jakarta</artifactId>
-    <version>2.1.3</version>
+    <version>3.0.0</version>
   </dependency>
 </dependencies>
 <plugin>
@@ -40,7 +40,7 @@ Example:
       <artifactItem>
         <groupId>io.openliberty.arquillian</groupId>
         <artifactId>arquillian-liberty-support-jakarta</artifactId>
-        <version>2.1.3</version>
+        <version>3.0.0</version>
         <type>zip</type>
         <classifier>feature</classifier>
         <overWrite>false</overWrite>
@@ -50,12 +50,12 @@ Example:
   </configuration>
 </plugin>
 ```
-Then add `<feature>usr:arquillian-support-jakarta-2.1</feature>` to the `<featureManager>` section of your `server.xml`.
+Then add `<feature>usr:arquillian-support-jakarta-3.0</feature>` to the `<featureManager>` section of your `server.xml`.
 ```
 <featureManager>
     <feature>pages-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-jakarta-2.1</feature>
+    <feature>usr:arquillian-support-jakarta-3.0</feature>
 </featureManager>
 ```
 
@@ -67,12 +67,12 @@ git clone git@github.com:OpenLiberty/liberty-arquillian.git
 mvn install
 ```
 2.  Extract the arquillian-liberty-support-jakarta-x.x.x-feature.zip into the `usr` directory of your Liberty runtime
-3. Add `<feature>usr:arquillian-support-jakarta-2.1</feature>` to the `<featureManager>` section of your `server.xml`
+3. Add `<feature>usr:arquillian-support-jakarta-3.0</feature>` to the `<featureManager>` section of your `server.xml`
 
 ```
 <featureManager>
     <feature>pages-3.0</feature>
     <feature>localConnector-1.0</feature>
-    <feature>usr:arquillian-support-jakarta-2.1</feature>
+    <feature>usr:arquillian-support-jakarta-3.0</feature>
 </featureManager>
 ```

--- a/liberty-support-feature/JakartaEE9_README.md
+++ b/liberty-support-feature/JakartaEE9_README.md
@@ -8,6 +8,8 @@ It is only for supporting the running of Arquillian tests and must not be instal
 
 Requires Jakarta EE 9, 10 or 11. For Java EE 8 projects and below, check out the documentation [here](README.md).
 
+For Jakarta EE 9 projects using Java SE 8, you will need to use the 2.x versions of the Liberty Arquillian plugin.
+
 ## Configuring with a Maven project
 
 You can install the arquillian-liberty-support-jakarta feature as part of a maven build using the [maven-dependency-plugin:unpack goal](https://maven.apache.org/plugins/maven-dependency-plugin/unpack-mojo.html).

--- a/liberty-support-feature/README.md
+++ b/liberty-support-feature/README.md
@@ -6,7 +6,7 @@ The Arquillian support feature adds an additional http endpoint which the Arquil
 
 It is only for supporting the running of Arquillian tests and must not be installed on a production system.
 
-Requires Java EE 8 or below. For Jakarta EE 9 and 10 projects, check out the documentation [here](JakartaEE9_README.md).
+Requires Java EE 8 or below. For Jakarta EE 9, 10 and 11 projects, check out the documentation [here](JakartaEE9_README.md).
 
 ## Configuring with a Maven project
 

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>6.4.0</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <!-- Artifact Configuration -->
   <groupId>io.openliberty.arquillian</groupId>
   <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-  <version>3.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Arquillian Container Liberty Jakarta Parent</name>
   <description>Jakarta Liberty Container integrations for the Arquillian Project</description>
@@ -43,8 +43,9 @@
     <version.surefire.plugin>3.2.5</version.surefire.plugin>
 
     <!-- override from parent -->
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,9 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.7.0.Final</version.arquillian_core>
-    <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
+    <version.arquillian_core>1.9.1.Final</version.arquillian_core>
+    <version.arquillian_jakarta>10.0.0.Final</version.arquillian_jakarta>
+    <version.surefire.plugin>3.2.5</version.surefire.plugin>
 
     <!-- override from parent -->
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -62,6 +63,13 @@
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-build</artifactId>
         <version>${version.arquillian_core}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian.jakarta</groupId>
+        <artifactId>arquillian-jakarta-bom</artifactId>
+        <version>${version.arquillian_jakarta}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
#### Short description of what this resolves:

Update versions of arquillian and surefire to support Jakarta EE 11 TCK

#### Changes proposed in this pull request:

- Move up to arquillian 1.9.1.Final
- Move jakarta specific dependencies to 10.0.0.Final version with the new versioning that is done
- Update surefire dependency to 3.2.5
- Newer arquillian version support Java 11+ so stop running Java 8 test and add Java 21 testing

**Fixes**: #140
