### PR TITLE
Bump commons-io and Liberty runtime version for tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ main ]
+    branches: [ 2.x-maintenance ]
   pull_request:
-    branches: [ main ]
+    branches: [ 2.x-maintenance ]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java: [8, 11, 17]
         runtime: [ol, wlp-ee9, wlp-ee10]
-        runtime_version: [23.0.0.3]
+        runtime_version: [24.0.0.9]
         exclude:
         - java: 8
           runtime: wlp-ee10

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -387,7 +387,7 @@
         <dependency>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
-          <version>2.11.0</version>
+          <version>2.14.0</version>
         </dependency>
 
         <!-- Jakarta EE Spec APIs -->


### PR DESCRIPTION
#### Short description of what this resolves: Bump the version of commons-io and use more recent Liberty runtime for running tests.


#### Changes proposed in this pull request:

- Bump commons-io from 2.11.0 to 2.14.0
- Change Liberty runtime to 24.0.0.9