### PR TITLE
Prep for 3.0

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2018, 2024 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureSerializedExceptionLocator.java
@@ -62,7 +62,7 @@ public class SupportFeatureSerializedExceptionLocator implements DeploymentExcep
             if (status == 400) {
                 log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
             } else if (status != 200) {
-                log.info("Unable to receive serialized exception from server, is usr:arquillian-support-jakarta-2.1 installed?");
+                log.info("Unable to receive serialized exception from server, is usr:arquillian-support-jakarta-3.0 installed?");
             } else {
                 try (InputStream inStream = new ByteArrayInputStream((byte[]) response[1])) {
                     ObjectInputStream objStream = new ObjectInputStream(inStream);

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2018, 2024 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/exceptions/SupportFeatureTextExceptionLocator.java
@@ -102,7 +102,7 @@ public class SupportFeatureTextExceptionLocator implements DeploymentExceptionLo
             if (status == 400) {
                 log.warning("After " + appName + " failed to start, the server did not report an exception for that app");
             } else if (status != 200) {
-                log.info("Unable to receive text format exception from server, is usr:arquillian-support-jakarta-2.1 installed?");
+                log.info("Unable to receive text format exception from server, is usr:arquillian-support-jakarta-3.0 installed?");
             } else {
                 log.finer("Reading exception returned from server");
                 try (BufferedReader reader = new BufferedReader(new StringReader((String) response[1]))) {

--- a/liberty-managed/src/test/resources/restServer-with-management-ee10.xml
+++ b/liberty-managed/src/test/resources/restServer-with-management-ee10.xml
@@ -7,7 +7,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-4.0</feature>
         <feature>jndi-1.0</feature>
-        <feature>usr:arquillian-support-jakarta-2.1</feature>
+        <feature>usr:arquillian-support-jakarta-3.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 

--- a/liberty-managed/src/test/resources/restServer-with-management.xml
+++ b/liberty-managed/src/test/resources/restServer-with-management.xml
@@ -7,7 +7,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-3.0</feature>
         <feature>jndi-1.0</feature>
-        <feature>usr:arquillian-support-jakarta-2.1</feature>
+        <feature>usr:arquillian-support-jakarta-3.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 

--- a/liberty-managed/src/test/resources/server-with-management.xml
+++ b/liberty-managed/src/test/resources/server-with-management.xml
@@ -7,7 +7,7 @@
         <feature>localConnector-1.0</feature>
         <feature>cdi-3.0</feature>
         <feature>jndi-1.0</feature>
-        <feature>usr:arquillian-support-jakarta-2.1</feature>
+        <feature>usr:arquillian-support-jakarta-3.0</feature>
     </featureManager>
 
     <!-- To access this server from a remote client add a host attribute 

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>arquillian-liberty-remote-jakarta</artifactId>

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openliberty.arquillian</groupId>
     <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
+++ b/liberty-support-feature/src/feature/resources/arquillian-liberty-support.mf
@@ -1,10 +1,10 @@
 IBM-Feature-Version: 2
-IBM-ShortName: arquillian-support-jakarta-2.1
+IBM-ShortName: arquillian-support-jakarta-3.0
 Subsystem-Content: arquillian-liberty-support-jakarta; version=${parsedVersion.osgiVersion},
  com.ibm.websphere.appserver.localConnector-1.0; type="osgi.subsystem.feature"
 Subsystem-Description: Jakarta Liberty Feature to support integration for the Arquillian Project
 Subsystem-ManifestVersion: 1
 Subsystem-Name: Arquillian Support Jakarta Feature
-Subsystem-SymbolicName: io.openliberty.arquillian.arquillian-support-jakarta-2.1; visibility:=public
+Subsystem-SymbolicName: io.openliberty.arquillian.arquillian-support-jakarta-3.0; visibility:=public
 Subsystem-Type: osgi.subsystem.feature
 Subsystem-Version: ${parsedVersion.osgiVersion}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <!-- Artifact Configuration -->
   <groupId>io.openliberty.arquillian</groupId>
   <artifactId>arquillian-parent-liberty-jakarta</artifactId>
-  <version>2.1.4-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Arquillian Container Liberty Jakarta Parent</name>
   <description>Jakarta Liberty Container integrations for the Arquillian Project</description>


### PR DESCRIPTION
#### Short description of what this resolves: Prepare for a 3.0 release of liberty-arquillian.


#### Changes proposed in this pull request:

- Update snapshot version to `3.0-SNAPSHOT`
- Update `usr:arquillian-support-jakarta` feature version to `3.0`
- Update all references to `usr:arquillian-support-jakarta` feature to version `3.0`