### PR TITLE
Add allowAppDeployFailures boolean property

### DIFF
--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -101,7 +101,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 | fileDeleteRetries | Integer | 30 | How many times to attempt deleting a file |
 | standardFileDeleteRetryInterval | Integer | 50 | How long in milliseconds to wait between attempting to delete a file |
 | testProtocol | String | servlet | Arquillian protocol to contact the server to run a test (available: servlet or rest) |
-| checkAppTargetState | boolean | true | When disabled, deployed apps do not need to reach a particular expected state (typically STARTED), suppressing potential deployment exceptions. |
+| allowAppDeployFailures | boolean | false | When enabled, application deployment exceptions are not thrown. |
 
 
 ## Examples

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -100,7 +100,8 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 | outputToConsole | Boolean | true | When enabled output from the application server process will be emitted to stdout |
 | fileDeleteRetries | Integer | 30 | How many times to attempt deleting a file |
 | standardFileDeleteRetryInterval | Integer | 50 | How long in milliseconds to wait between attempting to delete a file |
-| testProtocol | String | servlet | Aquillian protocol to contact the server to run a test (available: servlet or rest) |
+| testProtocol | String | servlet | Arquillian protocol to contact the server to run a test (available: servlet or rest) |
+| checkAppTargetState | boolean | true | When disabled, deployed apps do not need to reach a particular expected state (typically STARTED), suppressing potential deployment exceptions. |
 
 
 ## Examples

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -536,10 +536,11 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
              log.finer("Deployment done");
          }
 
-         if (containerConfiguration.isCheckAppTargetState()) {
+         try {
              waitForApplicationTargetState(new String[] {deployName}, true, containerConfiguration.getAppDeployTimeout());
-         } else {
-             Thread.sleep(containerConfiguration.getAppDeployTimeout() * 1000);
+         } catch (DeploymentException de) {
+             if (!containerConfiguration.isAllowAppDeployFailures())
+                 throw de;
          }
 
          // Return metadata on how to contact the deployed application
@@ -934,11 +935,12 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
             // Update server.xml on file system
             writeServerXML(document);
 
-            if (containerConfiguration.isCheckAppTargetState()) {
-               // Wait until the application is undeployed
-               waitForApplicationTargetState(new String[] {deployName}, false, containerConfiguration.getAppUndeployTimeout());
-            } else {
-               Thread.sleep(containerConfiguration.getAppUndeployTimeout() * 1000);
+            try {
+                // Wait until the application is undeployed
+                waitForApplicationTargetState(new String[] {deployName}, false, containerConfiguration.getAppUndeployTimeout());
+            } catch (DeploymentException de) {
+                if (!containerConfiguration.isAllowAppDeployFailures())
+                    throw de;
             }
          }
 

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -536,7 +536,11 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
              log.finer("Deployment done");
          }
 
-         waitForApplicationTargetState(new String[] {deployName}, true, containerConfiguration.getAppDeployTimeout());
+         if (containerConfiguration.isCheckAppTargetState()) {
+             waitForApplicationTargetState(new String[] {deployName}, true, containerConfiguration.getAppDeployTimeout());
+         } else {
+             Thread.sleep(containerConfiguration.getAppDeployTimeout() * 1000);
+         }
 
          // Return metadata on how to contact the deployed application
          ProtocolMetaData metaData = new ProtocolMetaData();
@@ -930,8 +934,12 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
             // Update server.xml on file system
             writeServerXML(document);
 
-            // Wait until the application is undeployed
-            waitForApplicationTargetState(new String[] {deployName}, false, containerConfiguration.getAppUndeployTimeout());
+            if (containerConfiguration.isCheckAppTargetState()) {
+               // Wait until the application is undeployed
+               waitForApplicationTargetState(new String[] {deployName}, false, containerConfiguration.getAppUndeployTimeout());
+            } else {
+               Thread.sleep(containerConfiguration.getAppUndeployTimeout() * 1000);
+            }
          }
 
          // Now we can proceed and delete the archive for either deploy type

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -46,7 +46,7 @@ public class WLPManagedContainerConfiguration implements
    private int fileDeleteRetries = 30; 
    private int standardFileDeleteRetryInterval = 50;
    private String testProtocol = "servlet";
-   private boolean checkAppTargetState = true;
+   private boolean allowAppDeployFailures = false;
 
    @Override
    public void validate() throws ConfigurationException {
@@ -314,11 +314,11 @@ public class WLPManagedContainerConfiguration implements
        return "servlet".equalsIgnoreCase(testProtocol);
    }
 
-   public boolean isCheckAppTargetState() {
-	   return checkAppTargetState;
+   public boolean isAllowAppDeployFailures() {
+	   return allowAppDeployFailures;
    }
 
-   public void setCheckAppTargetState(boolean checkAppTargetState) {
-	   this.checkAppTargetState = checkAppTargetState;
+   public void setAllowAppDeployFailures(boolean allowAppDeployFailures) {
+	   this.allowAppDeployFailures = allowAppDeployFailures;
    }
 }

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -46,6 +46,7 @@ public class WLPManagedContainerConfiguration implements
    private int fileDeleteRetries = 30; 
    private int standardFileDeleteRetryInterval = 50;
    private String testProtocol = "servlet";
+   private boolean checkAppTargetState = true;
 
    @Override
    public void validate() throws ConfigurationException {
@@ -311,5 +312,13 @@ public class WLPManagedContainerConfiguration implements
 
    public boolean isServletTestProtocol() {
        return "servlet".equalsIgnoreCase(testProtocol);
+   }
+
+   public boolean isCheckAppTargetState() {
+	   return checkAppTargetState;
+   }
+
+   public void setCheckAppTargetState(boolean checkAppTargetState) {
+	   this.checkAppTargetState = checkAppTargetState;
    }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
The WebSocket TCK contains some negative deployment tests that attempt to deploy applications that are expected to fail, but then need to proceed into test methods in order to check that various endpoints have not been registered. Currently, these failing applications prevent Arquillian from creating a URL suitable for testing.


#### Changes proposed in this pull request:

- Create a new allowAppDeployFailures property that defaults to false, maintaining normal, expected behavior
- Setting this new property to true will ignore any deploy exceptions that occur while processing all applications. In the case of an ignored exception, the plugin will proceed to create a best guess URL for the application that Arquillian can use for testing.


**Fixes**: https://github.com/OpenLiberty/liberty-arquillian/issues/137
