### PR TITLE
Support Deployment of Standalone EJB Jars

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2023 IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2012, 2025 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
#### Short description of what this resolves:
Liberty supports more app types than what the plugin currently allows. This item adds support for jars of type 'ejb.'


#### Changes proposed in this pull request:
- Deploy jars to dropins/ejb
- Support deployment of jars of type 'ejb' to server.xml

Note that there can be other types of jar files that are installable, e.g. 'spring'. Should we need to support those in the future, we would likely need to add a property to allow the user to configure what type to use to handle jars. This update simply assumes that jars are of 'ejb' type.