### PR TITLE
Updates to config for new Maven Central portal

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java: [11, 17, 21]
         runtime: [ol, wlp-ee9, wlp-ee10]
-        runtime_version: [24.0.0.9]
+        runtime_version: [25.0.0.9]
+        exclude:
+        - java: 21
+          runtime: wlp-ee9
 
     steps:
     - uses: actions/checkout@v3

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -16,6 +16,7 @@
   <artifactId>arquillian-liberty-managed-jakarta</artifactId>
   <name>Arquillian Container Liberty Jakarta Managed</name>
   <description>Jakarta Liberty Managed Container integration for the Arquillian Project</description>
+  <url>https://github.com/OpenLiberty/liberty-arquillian</url>
 
   <properties>
     <skipTests>false</skipTests>
@@ -75,7 +76,7 @@
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.11.5</version>
         <configuration>
           <skip>${skipTests}</skip>
           <serverName>defaultServer</serverName>
@@ -163,7 +164,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.1.1</version>
+            <version>3.8.1</version>
             <executions>
               <execution>
                 <id>extract-support-feature</id>
@@ -387,7 +388,7 @@
         <dependency>
           <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
-          <version>2.14.0</version>
+          <version>2.20.0</version>
         </dependency>
 
         <!-- Jakarta EE Spec APIs -->

--- a/liberty-remote/pom.xml
+++ b/liberty-remote/pom.xml
@@ -11,11 +11,12 @@
   <!-- Artifact Configuration -->
   <name>Arquillian Container Liberty Jakarta Remote</name>
   <description>Jakarta Liberty Remote Container integration for the Arquillian Project</description>
+  <url>https://github.com/OpenLiberty/liberty-arquillian</url>
 
   <properties>
     <skipTests>false</skipTests>
-    <version.jackson>2.13.4.2</version.jackson>
-    <version.apache.fluent.hc>4.5.6</version.apache.fluent.hc>
+    <version.jackson>2.20.0</version.jackson>
+    <version.apache.fluent.hc>4.5.14</version.apache.fluent.hc>
     <loggingPropertiesFile>${basedir}/src/test/resources/logging.properties</loggingPropertiesFile>
   </properties>
   
@@ -102,7 +103,7 @@
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.11.5</version>
         <executions>
           <execution>
             <id>start-server</id>

--- a/liberty-support-feature/pom.xml
+++ b/liberty-support-feature/pom.xml
@@ -16,13 +16,14 @@
   <artifactId>arquillian-liberty-support-jakarta</artifactId>
   <name>Arquillian Container Liberty Support Jakarta Feature</name>
   <description>Jakarta Liberty Feature to support integration for the Arquillian Project</description>
+  <url>https://github.com/OpenLiberty/liberty-arquillian</url>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>parse-version</id>
@@ -49,7 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -78,7 +79,7 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>copy-resources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <!-- Parent -->
-  <parent>
-    <groupId>net.wasdev.maven.parent</groupId>
-    <artifactId>parent</artifactId>
-    <version>1.4</version>
-    <relativePath />
-  </parent>
-
   <!-- Model Version -->
   <modelVersion>4.0.0</modelVersion>
 
@@ -19,6 +11,7 @@
   <packaging>pom</packaging>
   <name>Arquillian Container Liberty Jakarta Parent</name>
   <description>Jakarta Liberty Container integrations for the Arquillian Project</description>
+  <url>https://github.com/OpenLiberty/liberty-arquillian</url>
 
   <licenses>
     <license>
@@ -28,6 +21,16 @@
     </license>
   </licenses>
 
+  <developers>
+    <developer>
+      <name>Cheryl King</name>
+      <id>developers</id>
+      <email>developers@openliberty.io</email>
+      <organization>Open Liberty</organization>
+      <url>https://github.com/OpenLiberty</url>
+    </developer>
+  </developers>
+
   <scm>
     <connection>scm:git:git@github.com:OpenLiberty/liberty-arquillian.git</connection>
     <developerConnection>scm:git:git@github.com:OpenLiberty/liberty-arquillian.git</developerConnection>
@@ -35,17 +38,31 @@
     <tag>HEAD</tag>
   </scm>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>maven-central-snapshots</id>
+      <name>Maven Central Snapshot Repository</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </snapshotRepository>
+    <repository>
+      <id>maven-central-releases</id>
+      <name>Maven Central Release Repository</name>
+      <url>https://central.sonatype.com/api/v1/publisher</url>
+    </repository>
+  </distributionManagement>
+
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
     <version.arquillian_core>1.9.1.Final</version.arquillian_core>
     <version.arquillian_jakarta>10.0.0.Final</version.arquillian_jakarta>
-    <version.surefire.plugin>3.2.5</version.surefire.plugin>
+    <version.surefire.plugin>3.5.4</version.surefire.plugin>
 
     <!-- override from parent -->
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
+    <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -82,6 +99,22 @@
     <module>liberty-remote</module>
     <module>liberty-support-feature</module>
   </modules>
+
+  <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>3.1.1</version>
+            <configuration>
+                <autoVersionSubmodules>true</autoVersionSubmodules>
+                <useReleaseProfile>false</useReleaseProfile>
+                <releaseProfiles>sonatype-oss-release</releaseProfiles>
+                <goals>deploy</goals>
+            </configuration>
+        </plugin>        
+    </plugins>
+  </build>
 
   <!-- Profiles for WLP vs OL -->
   <profiles>
@@ -160,8 +193,69 @@
         <runtime>ol</runtime>
         <runtimeGroupId>io.openliberty</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <libertyVersion>23.0.0.3</libertyVersion>
+        <libertyVersion>25.0.0.9</libertyVersion>
       </properties>
+    </profile>
+    <profile>
+        <id>sonatype-oss-release</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>maven-central-releases</publishingServerId>
+                        <deploymentName>${project.artifactId}</deploymentName>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.3.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.11.2</version>
+                    <configuration>
+                        <bottom><![CDATA[Copyright &#169; {currentYear} the original author or authors.]]></bottom>
+                        <failOnError>false</failOnError>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.2.8</version>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Updates needed for new Maven Central portal for publishing snapshots and releases. Also updated some old dependency versions, and excluded running the wlp-jakartaee9 runtime on Java 21, which is not supported (version 23.0.0.2 came out before Java 21 support was added).