### PR TITLE
Add delegation property to classloader config

### DIFF
--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -90,6 +90,7 @@ To enable Arquillian Liberty Managed in your project, add the following to your 
 | securityConfiguration | String | None | When using xml deployType the referred file will be embedded within the application tag into the server.xml and should be used to configure the security settings. |
 | failSafeUndeployment | String | None | In some scenarios the xml deployType deployments might fail to undeploy because of an open FileHandle on Windows when using an Oracle JVM. Enabling this flag suppresses the exception to be thrown and marks the file to be delete upon exiting the JVM process. |
 | apiTypeVisibility | String | None | String that will be set as the apiTypeVisibility attribute of the application/classloader configuration element. See the [WLP Knowledge Center](https://www.ibm.com/support/knowledgecenter/en/SSEQTP_8.5.5/com.ibm.websphere.wlp.doc/ae/twlp_classloader_3p_apis.html) for possible values and default used when this value is not provided. |
+| delegation | String | parentFirst | String that will be set as the delegation attribute of the application/classloader configuration element. Possible values are parentFirst and parentLast. |
 | verifyApps | String | None | Specifies a comma-separated list of names of applications that will be verified to be started before tests are executed |
 | verifyAppDeployTimeout | Integer | 20 | Time in seconds to wait for the verifyApps application deployment to complete and the applications to start |
 | serverStartTimeout | Integer | 30 | Time in seconds to wait for the application server to start |

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -1159,7 +1159,8 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
 
       // create shared library
       if (containerConfiguration.getSharedLib() != null
-          ||containerConfiguration.getApiTypeVisibility() != null) {
+          || containerConfiguration.getApiTypeVisibility() != null
+          || containerConfiguration.getDelegation() != null) {
 
          Element classloader = doc.createElement("classloader");
 
@@ -1169,6 +1170,10 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
 
          if (containerConfiguration.getApiTypeVisibility() != null) {
             classloader.setAttribute("apiTypeVisibility", containerConfiguration.getApiTypeVisibility());
+         }
+
+         if (containerConfiguration.getDelegation() != null) {
+            classloader.setAttribute("delegation", containerConfiguration.getDelegation());
          }
          application.appendChild(classloader);
       }

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012, 2022 IBM Corporation, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2012, 2025 IBM Corporation, Red Hat Middleware LLC, and individual contributors
  * identified by the Git commit log. 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,7 @@ public class WLPManagedContainerConfiguration implements
    private int appUndeployTimeout = 2;
    private String sharedLib = null;
    private String apiTypeVisibility = null;
+   private String delegation = null;
    private String deployType = "dropins";
    private String javaVmArguments = "";
    private boolean addLocalConnector;
@@ -98,11 +99,19 @@ public class WLPManagedContainerConfiguration implements
          }
       }
       
-      //Validate apiTypeVisibility
+      // Validate apiTypeVisibility
       if (apiTypeVisibility != null) {
          if (!apiTypeVisibility.isEmpty()) {
             if (!deployType.equalsIgnoreCase("xml"))
                throw new ConfigurationException("deployType must be set to xml when apiTypeVisibility is not empty");
+         }
+      }
+
+      // Validate delegation
+      if (delegation != null) {
+         if (!delegation.isEmpty()) {
+            if (!deployType.equalsIgnoreCase("xml"))
+               throw new ConfigurationException("deployType must be set to xml when delegation is not empty");
          }
       }
 
@@ -167,6 +176,13 @@ public class WLPManagedContainerConfiguration implements
       return apiTypeVisibility;
    }
 
+   public void setDelegation(String delegation) {
+      this.delegation = delegation;
+   }
+
+   public String getDelegation() {
+      return delegation;
+   }
    
    public void setDeployType(String deployType) {
       this.deployType = deployType;

--- a/liberty-managed/src/test/resources/arquillian.xml
+++ b/liberty-managed/src/test/resources/arquillian.xml
@@ -26,6 +26,7 @@
       <!-- the values below are the documented default, so it is not changing anything,
            other than testing these code paths -->
       <property name="apiTypeVisibility">spec, ibm-api, api</property>
+      <property name="delegation">parentFirst</property>
 
       <!-- Adjust timeouts to work on Cloudbees CI server -->
       <property name="appDeployTimeout">60</property>


### PR DESCRIPTION
Adds support for the optional `delegation` property of application classloader config. This is needed to enable some of the reworked EE 11 Platform TCK.

[See Liberty documentation for details on the property -- https://www.ibm.com/docs/en/was-liberty/base?topic=configuration-classloader]