### PR TITLE
Support defaultClientModule attribute

### DIFF
--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainer.java
@@ -957,7 +957,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
                 // Read client.xml file into Memory
                 Document clientDoc = readClientXML();
 
-                // Add the archive as appropriate to the client.xml file
+                // Remove the archive from the client.xml file
                 removeEnterpriseApplication(clientDoc, deployName);
 
                 // Update client.xml on file system

--- a/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
+++ b/liberty-managed/src/main/java/io/openliberty/arquillian/managed/WLPManagedContainerConfiguration.java
@@ -49,6 +49,9 @@ public class WLPManagedContainerConfiguration implements
    private String testProtocol = "servlet";
    private boolean allowAppDeployFailures = false;
 
+   private String clientName = null;
+   private String defaultClientModule = null;
+
    @Override
    public void validate() throws ConfigurationException {
       // Validate wlpHome
@@ -125,6 +128,24 @@ public class WLPManagedContainerConfiguration implements
 
       if (!"rest".equalsIgnoreCase(testProtocol) && !"servlet".equalsIgnoreCase(testProtocol)) {
           throw new ConfigurationException("testProtocol must be set to rest or servlet");
+      }
+
+      // Validate clientName
+      // Use only Unicode alphanumeric (e.g. 0-9, a-z, A-Z), underscore (_), dash (-), plus (+), and period (.) characters.
+      // Do not begin with a dash (-) or a period (.).
+      if (clientName != null) {
+          if (!clientName.matches("^[A-Za-z0-9\\+_][A-Za-z0-9\\+_\\.-]*$"))
+              throw new ConfigurationException("clientName provided is not valid: '" + clientName + "'");
+      }
+
+      // Validate defaultClientModule
+      if (defaultClientModule != null) {
+         if (!defaultClientModule.isEmpty()) {
+            if (!deployType.equalsIgnoreCase("xml"))
+               throw new ConfigurationException("deployType must be set to xml when defaultClientModule is not empty");
+            else if (clientName == null)
+               throw new ConfigurationException("clientName must be set when defaultClientModule is not empty");
+         }
       }
    }
 
@@ -331,10 +352,26 @@ public class WLPManagedContainerConfiguration implements
    }
 
    public boolean isAllowAppDeployFailures() {
-	   return allowAppDeployFailures;
+       return allowAppDeployFailures;
    }
 
    public void setAllowAppDeployFailures(boolean allowAppDeployFailures) {
-	   this.allowAppDeployFailures = allowAppDeployFailures;
+       this.allowAppDeployFailures = allowAppDeployFailures;
+   }
+
+   public String getClientName() {
+       return clientName;
+   }
+
+   public void setClientName(String clientName) {
+       this.clientName = clientName;
+   }
+
+   public String getDefaultClientModule() {
+       return defaultClientModule;
+   }
+
+   public void setDefaultClientModule(String defaultClientModule) {
+       this.defaultClientModule = defaultClientModule;
    }
 }


### PR DESCRIPTION
Provides basic support for deploying applications to the appclient and creating client-side config, but is only enabled if the `defaultClientModule` attribute is requested.

This does not provide support for using `defaultClientModule` in server-side config, even though it's a valid attribute there.

The `defaultClientModule` is needed for the edge case where an application contains more than one client module, so Open Liberty knows which one is intended to be invoked.