### PR TITLE
Update JakartaEE9_README.mds to include info on Arquillian versions

### DIFF
--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -10,7 +10,16 @@ This `DeployableContainer` has been tested with the latest release of Open Liber
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
-For Jakarta EE 9 projects using Java SE 8, you will need to use the 2.x versions of the Liberty Arquillian plugin.
+For Jakarta EE projects, use this table to determine which version of the Arquillian plugin to use:
+
+| Arquillian Version + Java Level | Jakarta EE 9 | Jakarta EE 10 | Jakarta EE 11 |
+|----------------------------------|--------------|---------------|---------------|
+| 2.x + Java 8                     | ✅           | ❌            | ❌            |
+| 2.x + Java 11                    | ✅           | ✅            | ❌            |
+| 2.x + Java 17                    | ✅           | ✅            | ✅            |
+| 3.x + Java 11                    | ✅           | ✅            | ❌            |
+| 3.x + Java 17                    | ✅           | ✅            | ✅            |
+| 3.x + Java 21                    | ✅           | ✅            | ✅            |
 
 **Prerequisite Configuration**
 

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -10,7 +10,17 @@ This `DeployableContainer` has been tested with the latest release of Open Liber
 
 For Java EE 8 projects and below, check out the documentation [here](README.md).
 
-For Jakarta EE 9 projects using Java SE 8, you will need to use the 2.x versions of the Liberty Arquillian plugin.
+For Jakarta EE projects, use this table to determine which version of the Arquillian plugin to use:
+
+| Arquillian Version + Java Level | Jakarta EE 9 | Jakarta EE 10 | Jakarta EE 11 |
+|----------------------------------|--------------|---------------|---------------|
+| 2.x + Java 8                     | ✅           | ❌            | ❌            |
+| 2.x + Java 11                    | ✅           | ✅            | ❌            |
+| 2.x + Java 17                    | ✅           | ✅            | ✅            |
+| 3.x + Java 11                    | ✅           | ✅            | ❌            |
+| 3.x + Java 17                    | ✅           | ✅            | ✅            |
+| 3.x + Java 21                    | ✅           | ✅            | ✅            |
+
 
 **Prerequisite Configuration**
 


### PR DESCRIPTION
Update the readme files to include tables to help users understand which version of the plugin to use based on Java and Jakarta EE level. 