### PR TITLE
Updates for tests for EE11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,6 +19,8 @@ jobs:
         exclude:
         - java: 21
           runtime: wlp-ee9
+        - java: 11
+          runtime: wlp-ee11
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,10 +13,12 @@ jobs:
       max-parallel: 7
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [11, 17, 21]
+        java: [11, 17, 21, 25]
         runtime: [ol, wlp-ee9, wlp-ee10, wlp-ee11]
         runtime_version: [26.0.0.5]
         exclude:
+        - java: 25
+          runtime: wlp-ee9
         - java: 21
           runtime: wlp-ee9
         - java: 11

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         java: [11, 17, 21]
-        runtime: [ol, wlp-ee9, wlp-ee10]
-        runtime_version: [25.0.0.9]
+        runtime: [ol, wlp-ee9, wlp-ee10, wlp-ee11]
+        runtime_version: [26.0.0.5]
         exclude:
         - java: 21
           runtime: wlp-ee9

--- a/liberty-managed/JakartaEE9_README.md
+++ b/liberty-managed/JakartaEE9_README.md
@@ -20,6 +20,7 @@ For Jakarta EE projects, use this table to determine which version of the Arquil
 | 3.x + Java 11                    | ✅           | ✅            | ❌            |
 | 3.x + Java 17                    | ✅           | ✅            | ✅            |
 | 3.x + Java 21                    | ✅           | ✅            | ✅            |
+| 3.x + Java 25                    | ✅           | ✅            | ✅            |
 
 **Prerequisite Configuration**
 

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -159,6 +159,20 @@
                   <goal>create</goal>
                  </goals>
           </execution>
+          <execution>
+            <id>create-rest-server-management-ee11</id>
+            <!-- Plugin execution only succeeds here in the correct order because
+                 execution id of the test is not 'default-test'.
+                 Because Maven. See MNG-5799 and MNG-5987 -->
+                 <phase>test</phase>
+                 <configuration>
+                  <serverName>managementRestServer-ee11</serverName>
+                  <serverXmlFile>src/test/resources/restServer-with-management-ee11.xml</serverXmlFile>
+                 </configuration>
+                 <goals>
+                  <goal>create</goal>
+                 </goals>
+          </execution>
         </executions>
         </plugin>
           <plugin>
@@ -326,6 +340,25 @@
                   <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-rest-ee10-test</reportsDirectory>
                   <systemPropertyVariables>
                     <arquillian.launch>wlp-xml-management-deployment-rest-ee10</arquillian.launch>
+                  </systemPropertyVariables>
+                  <includes>
+                    <include>**/needssupportfeature/**</include>
+                  </includes>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>wlp-xml-management-deployment-rest-ee11-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>${skipTests}</skip>
+                  <skip>${skipEE11Tests}</skip>
+                  <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-rest-ee11-test</reportsDirectory>
+                  <systemPropertyVariables>
+                    <arquillian.launch>wlp-xml-management-deployment-rest-ee11</arquillian.launch>
                   </systemPropertyVariables>
                   <includes>
                     <include>**/needssupportfeature/**</include>

--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -43,6 +43,7 @@
       </activation>
       <properties>
         <skipEE10Tests>true</skipEE10Tests>
+        <skipEE11Tests>true</skipEE11Tests>
       </properties>
       <dependencies>
         <dependency>
@@ -59,6 +60,9 @@
       <activation>
           <jdk>[11,)</jdk>
       </activation>
+      <properties>
+        <skipEE11Tests>true</skipEE11Tests>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>jakarta.annotation</groupId>

--- a/liberty-managed/src/test/resources/arquillian.xml
+++ b/liberty-managed/src/test/resources/arquillian.xml
@@ -86,12 +86,24 @@
       <property name="appUndeployTimeout">10</property>
     </configuration>
   </container>
-
   <container qualifier="wlp-xml-management-deployment-rest-ee10">
     <configuration>
       <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
       <property name="deployType">xml</property>
       <property name="serverName">managementRestServer-ee10</property>
+      <property name="testProtocol">rest</property>
+
+      <!-- Adjust timeouts to work on Cloudbees CI server -->
+      <property name="appDeployTimeout">60</property>
+      <property name="appUndeployTimeout">10</property>
+    </configuration>
+  </container>
+
+  <container qualifier="wlp-xml-management-deployment-rest-ee11">
+    <configuration>
+      <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
+      <property name="deployType">xml</property>
+      <property name="serverName">managementRestServer-ee11</property>
       <property name="testProtocol">rest</property>
 
       <!-- Adjust timeouts to work on Cloudbees CI server -->

--- a/liberty-managed/src/test/resources/restServer-with-management-ee11.xml
+++ b/liberty-managed/src/test/resources/restServer-with-management-ee11.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <platform>jakartaee-11.0</platform>
+        <feature>restfulWS</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>cdi</feature>
+        <feature>jndi-1.0</feature>
+        <feature>usr:arquillian-support-jakarta-3.0</feature>
+    </featureManager>
+
+    <!-- To access this server from a remote client add a host attribute 
+        to the following element, e.g. host="*" -->
+    <httpEndpoint httpPort="9080" httpsPort="9443"
+        id="defaultHttpEndpoint" />
+
+    <applicationMonitor updateTrigger="mbean" />
+
+    <jndiEntry jndiName="env/foo" value="${env.foo}" />
+</server>

--- a/liberty-remote/JakartaEE9_README.md
+++ b/liberty-remote/JakartaEE9_README.md
@@ -20,6 +20,7 @@ For Jakarta EE projects, use this table to determine which version of the Arquil
 | 3.x + Java 11                    | ✅           | ✅            | ❌            |
 | 3.x + Java 17                    | ✅           | ✅            | ✅            |
 | 3.x + Java 21                    | ✅           | ✅            | ✅            |
+| 3.x + Java 25                    | ✅           | ✅            | ✅            |
 
 
 **Prerequisite Configuration**

--- a/liberty-remote/src/test/resources/restServer.xml
+++ b/liberty-remote/src/test/resources/restServer.xml
@@ -17,6 +17,7 @@
 	<!-- userName and password should also be set in arquillian.xml to these 
 		values -->
 	<quickStartSecurity userName="admin" userPassword="admin" />
+    <ltpa keysPassword="WebAS"/>
 
 	<!-- Enable the keystore -->
 	<keyStore id="defaultKeyStore" password="password" location="key.jks" type="JKS"/>

--- a/liberty-remote/src/test/resources/server.xml
+++ b/liberty-remote/src/test/resources/server.xml
@@ -17,6 +17,7 @@
 	<!-- userName and password should also be set in arquillian.xml to these 
 		values -->
 	<quickStartSecurity userName="admin" userPassword="admin" />
+    <ltpa keysPassword="WebAS"/>
 
 	<!-- Enable the keystore -->
 	<keyStore id="defaultKeyStore" password="password" location="key.jks" type="JKS"/>

--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,10 @@
           <runtime>wlp-ee9</runtime>
           <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
           <runtimeArtifactId>wlp-jakartaee9</runtimeArtifactId>
+          <!-- This is the final version published for this artifact -->
           <libertyVersion>23.0.0.2</libertyVersion>
           <skipEE10Tests>true</skipEE10Tests>
+          <skipEE11Tests>true</skipEE11Tests>
       </properties>
     </profile>
     <profile>
@@ -146,8 +148,27 @@
           <runtime>wlp-ee10</runtime>
           <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
           <runtimeArtifactId>wlp-jakartaee10</runtimeArtifactId>
+          <!-- This is the final version published for this artifact -->
+          <libertyVersion>26.0.0.4</libertyVersion>
+          <skipEE9Tests>true</skipEE9Tests>
+          <skipEE11Tests>true</skipEE11Tests>
+      </properties>
+    </profile>
+    <profile>
+      <id>wlp-ee11-its</id>
+      <activation>
+          <property>
+            <name>runtime</name>
+            <value>wlp-ee11</value>
+          </property>
+      </activation>
+      <properties>
+          <runtime>wlp-ee11</runtime>
+          <runtimeGroupId>com.ibm.websphere.appserver.runtime</runtimeGroupId>
+          <runtimeArtifactId>wlp-jakartaee11</runtimeArtifactId>
           <libertyVersion>${runtimeVersion}</libertyVersion>
           <skipEE9Tests>true</skipEE9Tests>
+          <skipEE10Tests>true</skipEE10Tests>
       </properties>
     </profile>
     <profile>
@@ -193,7 +214,7 @@
         <runtime>ol</runtime>
         <runtimeGroupId>io.openliberty</runtimeGroupId>
         <runtimeArtifactId>openliberty-runtime</runtimeArtifactId>
-        <libertyVersion>25.0.0.9</libertyVersion>
+        <libertyVersion>26.0.0.5</libertyVersion>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Added test for Jakarta EE 11, pinned the version for Liberty runtime for the Jakarta EE 10 tests and ensured the correct tests run for the correct profile.